### PR TITLE
fix: Allow both return and enter to apply filter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1883,7 +1883,7 @@ export const App = () => {
 				setFilterMode(false)
 				return
 			}
-			if (key.name === "enter") {
+			if (key.name === "return" || key.name === "enter") {
 				setFilterQuery(filterDraft)
 				setFilterMode(false)
 				return


### PR DESCRIPTION
In some terminals the enter key reports as "return", this was the case for me in ghostty. Because of this, the filter wouldn't apply when being entered.

Full disclosure:
I did use AI assisted tooling in the fix. I am a human though and the fix seems reasonable to me and it's the same behavior that's shown multiple other places in the app.