### PR TITLE
feat: Allow a preset filter as a query param

### DIFF
--- a/bin/ghui.js
+++ b/bin/ghui.js
@@ -32,6 +32,9 @@ Usage:
   ghui -v, --version
                     Print the installed version
   ghui -h, --help   Show this help message
+
+Options:
+  -f, --filter <query>  Start with a preset filter query
 `
 
 const run = (target, args = process.argv.slice(2)) => {
@@ -55,6 +58,14 @@ if (process.argv[2] === "-h" || process.argv[2] === "--help" || process.argv[2] 
 if (process.argv[2] === "-v" || process.argv[2] === "--version" || process.argv[2] === "version") {
 	console.log(packageJson.version)
 	process.exit(0)
+}
+
+if (process.argv[2] === "-f" || process.argv[2] === "--filter") {
+	if (!process.argv[3] || process.argv[3].startsWith("-")) {
+		console.error("Error: --filter requires a query value.")
+		console.error('Usage: ghui --filter <query>')
+		process.exit(1)
+	}
 }
 
 if (process.argv[2] === "upgrade") {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -306,7 +306,11 @@ const pullRequestsAtom = githubRuntime
 const wrapIndex = (index: number, length: number) => (length === 0 ? 0 : ((index % length) + length) % length)
 const selectedIndexAtom = Atom.make(0)
 const noticeAtom = Atom.make<string | null>(null)
-const filterQueryAtom = Atom.make("")
+const initialFilter = (() => {
+	const index = process.argv.findIndex((arg) => arg === "--filter" || arg === "-f")
+	return index !== -1 ? (process.argv[index + 1] ?? "") : ""
+})()
+const filterQueryAtom = Atom.make(initialFilter)
 const filterDraftAtom = Atom.make("")
 const filterModeAtom = Atom.make(false)
 const detailFullViewAtom = Atom.make(false)

--- a/src/standalone.ts
+++ b/src/standalone.ts
@@ -9,6 +9,9 @@ Usage:
   ghui -v, --version
                     Print the installed version
   ghui -h, --help   Show this help message
+
+Options:
+  -f, --filter <query>  Start with a preset filter query
 `
 
 const args = Bun.argv.slice(2)
@@ -43,7 +46,13 @@ if (command === "upgrade") {
 	process.exit(1)
 }
 
-if (typeof command === "string") {
+if (command === "-f" || command === "--filter") {
+	if (!args[1] || args[1].startsWith("-")) {
+		console.error("Error: --filter requires a query value.")
+		console.error("Usage: ghui --filter <query>")
+		process.exit(1)
+	}
+} else if (typeof command === "string") {
 	const unknownCommand = command
 	const suggestion = commands.find((name) => editDistance(unknownCommand, name) <= 2)
 	console.error(`Unknown command: ${unknownCommand}`)


### PR DESCRIPTION
When I go to work I want to open the ghui only to my work-related repos, this allows me to do so by either using --filter or -f.

```
> ghui -f company-name
```

Full disclosure: I did use AI assisted tooling in this PR, but I am a human and have reviewed and tested this.