### PR TITLE
Add CLI utility commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ Run it from anywhere:
 ghui
 ```
 
+CLI commands:
+
+```bash
+ghui --help       # show usage
+ghui -h           # show usage
+ghui -v           # print installed version
+ghui --version    # print installed version
+ghui upgrade      # install the latest npm release globally
+```
+
 <img width="1420" height="856" alt="image" src="https://github.com/user-attachments/assets/5e560a4a-5887-4baa-a6d4-e1f4f0410c70" />
 
 ## Local Development

--- a/bin/ghui.js
+++ b/bin/ghui.js
@@ -1,3 +1,66 @@
 #!/usr/bin/env bun
 
-import "../src/index.tsx"
+const packageJson = await Bun.file(new URL("../package.json", import.meta.url)).json()
+
+const help = `ghui ${packageJson.version}
+
+Terminal UI for GitHub pull requests.
+
+Usage:
+  ghui              Start the TUI
+  ghui upgrade      Upgrade ghui to the latest npm release
+  ghui -v, --version
+                    Print the installed version
+  ghui -h, --help   Show this help message
+`
+
+const args = Bun.argv.slice(2)
+const command = args[0]
+const commands = ["upgrade", "help", "version"]
+
+const editDistance = (a, b) => {
+	const distances = Array.from({ length: a.length + 1 }, (_, i) => [i])
+	for (let j = 1; j <= b.length; j++) distances[0][j] = j
+
+	for (let i = 1; i <= a.length; i++) {
+		for (let j = 1; j <= b.length; j++) {
+			distances[i][j] = Math.min(
+				distances[i - 1][j] + 1,
+				distances[i][j - 1] + 1,
+				distances[i - 1][j - 1] + (a[i - 1] === b[j - 1] ? 0 : 1),
+			)
+		}
+	}
+
+	return distances[a.length][b.length]
+}
+
+if (command === "-h" || command === "--help" || command === "help") {
+	console.log(help)
+	process.exit(0)
+}
+
+if (command === "-v" || command === "--version" || command === "version") {
+	console.log(packageJson.version)
+	process.exit(0)
+}
+
+if (command === "upgrade") {
+	const proc = Bun.spawn({
+		cmd: ["npm", "install", "-g", `${packageJson.name}@latest`],
+		stdin: "inherit",
+		stdout: "inherit",
+		stderr: "inherit",
+	})
+	process.exit(await proc.exited)
+}
+
+if (command !== undefined) {
+	const suggestion = commands.find((name) => editDistance(command, name) <= 2)
+	console.error(`Unknown command: ${command}`)
+	if (suggestion) console.error(`Did you mean: ghui ${suggestion}?`)
+	console.error("Run `ghui --help` for usage.")
+	process.exit(1)
+}
+
+await import("../src/index.tsx")

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"ghui": "bin/ghui.js"
 	},
 	"scripts": {
-		"dev": "bun --watch src/index.tsx",
+		"dev": "bun --watch bin/ghui.js",
 		"start": "bun run src/index.tsx",
 		"test": "bun test test",
 		"typecheck": "tsc --noEmit"


### PR DESCRIPTION
## summary
- add CLI handling for help, version, upgrade, and unknown-command suggestions
- route the dev script through the published bin entrypoint so CLI flags can be tested locally
- document the new CLI commands in the README

## testing
- bun bin/ghui.js --help
- bun bin/ghui.js --version
- bun run dev -- uprade
- bun run dev -- --help
- bun run dev -- --version
- bun run typecheck