### PR TITLE
feat: Add lightweight keybinding system

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,25 @@ GHUI_AUTHOR=@me ghui
 
 You can also copy `.env.example` to `.env` and edit the values locally.
 
-## Keybindings
+## Custom Keybindings
+
+ghui reads its configuration from `~/.config/ghui/config.json` (or `$XDG_CONFIG_HOME/ghui/config.json`). Add a `keybindings` object to override any default binding:
+
+```json
+{
+  "keybindings": {
+    "merge": "ctrl+m",
+    "close": "ctrl+x",
+    "toggleDraft": ["ctrl+s", "shift+s"]
+  }
+}
+```
+
+Each key is an action name and each value is a key or array of keys. Use an array to bind multiple keys to one action. Keys can be plain (`"d"`, `"escape"`) or include modifiers (`"ctrl+m"`, `"shift+k"`, `"alt+x"`). An override fully replaces the defaults for that action.
+
+Available actions: `navigateUp`, `navigateDown`, `navigateGroupUp`, `navigateGroupDown`, `halfPageUp`, `halfPageDown`, `goToTop`, `goToBottom`, `select`, `back`, `openDiff`, `openInBrowser`, `copyMetadata`, `merge`, `close`, `toggleDraft`, `labels`, `refresh`, `filter`, `clearFilter`, `switchTab`, `toggleDiffView`, `toggleDiffWrap`, `enterCommentMode`, `jumpFileNext`, `jumpFilePrev`, `openTheme`, `quit`.
+
+## Default Keybindings
 
 - `up` / `down`: move selection
 - `k` / `j`: move selection

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,13 +6,13 @@ import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 import * as Atom from "effect/unstable/reactivity/Atom"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { config } from "./config.js"
-import { matchesAction } from "./keybindings.js"
+import { hintLabel, matchesAction as matchesActionWith, type Bindings } from "./keybindings.js"
 import { pullRequestQueueLabels, pullRequestQueueModes, type CreatePullRequestCommentInput, type DiffCommentSide, type LoadStatus, type PullRequestItem, type PullRequestLabel, type PullRequestMergeAction, type PullRequestQueueMode, type PullRequestReviewComment } from "./domain.js"
 import { formatShortDate, formatTimestamp } from "./date.js"
 import { availableMergeActions, mergeInfoFromPullRequest } from "./mergeActions.js"
 import { Observability } from "./observability.js"
 import { GitHubService } from "./services/GitHubService.js"
-import { loadStoredThemeId, saveStoredThemeId } from "./themeStore.js"
+import { loadStoredConfig, saveStoredThemeId } from "./configStore.js"
 import { colors, filterThemeDefinitions, setActiveTheme, themeDefinitions, type ThemeId } from "./ui/colors.js"
 import { backspace as editorBackspace, deleteForward as editorDeleteForward, deleteToLineEnd, deleteToLineStart, deleteWordBackward, deleteWordForward, insertText, moveLeft as editorMoveLeft, moveLineEnd, moveLineStart, moveRight as editorMoveRight, moveVertically, moveWordBackward, moveWordForward, type CommentEditorValue } from "./ui/commentEditor.js"
 import { buildStackedDiffFiles, diffCommentAnchorKey, diffCommentLocationKey, getStackedDiffCommentAnchors, nearestDiffCommentAnchorIndex, PullRequestDiffState, pullRequestDiffKey, safeDiffFileIndex, scrollTopForVisibleLine, splitPatchFiles, stackedDiffFileAtLine, type DiffCommentAnchor, type DiffView, type DiffWrapMode, type StackedDiffCommentAnchor } from "./ui/diff.js"
@@ -25,7 +25,11 @@ import { PullRequestDiffPane } from "./ui/PullRequestDiffPane.js"
 import { PullRequestList } from "./ui/PullRequestList.js"
 
 const githubRuntime = Atom.runtime(GitHubService.layer.pipe(Layer.provideMerge(Observability.layer)))
-const initialThemeId = await Effect.runPromise(loadStoredThemeId)
+const initialConfig = await Effect.runPromise(loadStoredConfig)
+const initialThemeId = initialConfig.themeId
+const bindings: Bindings = initialConfig.bindings
+const matchesAction: typeof matchesActionWith = (key, action) => matchesActionWith(key, action, bindings)
+const hint: typeof hintLabel = (action) => hintLabel(action, bindings)
 
 
 interface PullRequestLoad {
@@ -2244,6 +2248,7 @@ export const App = () => {
 						isLoading={pullRequestStatus === "loading" || isRefreshingPullRequests || isHydratingPullRequestDetails || closeModal.running || mergeModal.running}
 						loadingIndicator={loadingIndicator}
 						retryProgress={retryProgress}
+						hint={hint}
 					/>
 				)}
 			</box>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 import * as Atom from "effect/unstable/reactivity/Atom"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { config } from "./config.js"
+import { matchesAction } from "./keybindings.js"
 import { pullRequestQueueLabels, pullRequestQueueModes, type CreatePullRequestCommentInput, type DiffCommentSide, type LoadStatus, type PullRequestItem, type PullRequestLabel, type PullRequestMergeAction, type PullRequestQueueMode, type PullRequestReviewComment } from "./domain.js"
 import { formatShortDate, formatTimestamp } from "./date.js"
 import { availableMergeActions, mergeInfoFromPullRequest } from "./mergeActions.js"
@@ -288,7 +289,6 @@ const copyPullRequestMetadata = async (pullRequest: PullRequestItem) => {
 
 const isShiftG = (key: { readonly name: string; readonly shift?: boolean }) => key.name === "G" || key.name === "g" && key.shift
 
-const isThemeKey = (key: { readonly name: string; readonly ctrl?: boolean; readonly meta?: boolean }) => !key.ctrl && !key.meta && key.name.toLowerCase() === "t"
 
 const nextQueueMode = (mode: PullRequestQueueMode, delta: 1 | -1) => {
 	const index = pullRequestQueueModes.indexOf(mode)
@@ -1758,12 +1758,12 @@ export const App = () => {
 				return
 			}
 
-			if (key.name === "escape" || key.name === "return" || key.name === "enter") {
+			if (matchesAction(key, "back")) {
 				setDiffFullView(false)
 				setDiffCommentMode(false)
 				return
 			}
-			if (key.name === "c" && selectedDiffState?._tag === "Ready") {
+			if (matchesAction(key, "enterCommentMode") && selectedDiffState?._tag === "Ready") {
 				enterDiffCommentMode()
 				return
 			}
@@ -1800,28 +1800,28 @@ export const App = () => {
 				scrollDiffBy(halfPage)
 				return
 			}
-			if (key.name === "v") {
+			if (matchesAction(key, "toggleDiffView")) {
 				setDiffRenderView((current) => current === "unified" ? "split" : "unified")
 				return
 			}
-			if (key.name === "w") {
+			if (matchesAction(key, "toggleDiffWrap")) {
 				setDiffWrapMode((current) => current === "none" ? "word" : "none")
 				return
 			}
-			if (key.name === "r" && selectedPullRequest) {
+			if (matchesAction(key, "refresh") && selectedPullRequest) {
 				loadPullRequestDiff(selectedPullRequest, { force: true, includeComments: true })
 				flashNotice(`Refreshing diff for #${selectedPullRequest.number}`)
 				return
 			}
-			if ((key.name === "]" || key.name === "right" || key.name === "l") && selectedDiffState?._tag === "Ready") {
+			if (matchesAction(key, "jumpFileNext") && selectedDiffState?._tag === "Ready") {
 				jumpDiffFile(1)
 				return
 			}
-			if ((key.name === "[" || key.name === "left" || key.name === "h") && selectedDiffState?._tag === "Ready") {
+			if (matchesAction(key, "jumpFilePrev") && selectedDiffState?._tag === "Ready") {
 				jumpDiffFile(-1)
 				return
 			}
-			if (key.name === "o" && selectedPullRequest) {
+			if (matchesAction(key, "openInBrowser") && selectedPullRequest) {
 				openSelectedPullRequestInBrowser(selectedPullRequest)
 				return
 			}
@@ -1830,37 +1830,36 @@ export const App = () => {
 
 		// Fullscreen detail mode handles its own navigation keys.
 		if (detailFullView) {
-			const plainKey = !key.ctrl && !key.meta && !key.option
-			if (key.name === "escape" || (key.name === "return" || key.name === "enter")) {
+			if (matchesAction(key, "back")) {
 				setDetailFullView(false)
 				setDetailScrollOffset(0)
 				return
 			}
-			if (isThemeKey(key)) {
+			if (matchesAction(key, "openTheme")) {
 				openThemeModal()
 				return
 			}
-			if (plainKey && key.name === "d" && selectedPullRequest) {
+			if (matchesAction(key, "openDiff") && selectedPullRequest) {
 				openDiffView()
 				return
 			}
-			if (plainKey && key.name === "x" && selectedPullRequest?.state === "open") {
+			if (matchesAction(key, "close") && selectedPullRequest?.state === "open") {
 				openCloseModal()
 				return
 			}
-			if (plainKey && key.name === "l" && selectedPullRequest) {
+			if (matchesAction(key, "labels") && selectedPullRequest) {
 				openLabelModal()
 				return
 			}
-			if (plainKey && (key.name === "m" || key.name === "M") && selectedPullRequest) {
+			if (matchesAction(key, "merge") && selectedPullRequest) {
 				openMergeModal()
 				return
 			}
-			if (plainKey && (key.name === "s" || key.name === "S") && selectedPullRequest) {
+			if (matchesAction(key, "toggleDraft") && selectedPullRequest) {
 				toggleSelectedPullRequestDraftStatus()
 				return
 			}
-			if (plainKey && key.name === "r") {
+			if (matchesAction(key, "refresh")) {
 				refreshPullRequests("Refreshed")
 				return
 			}
@@ -1908,11 +1907,11 @@ export const App = () => {
 				setDetailScrollOffset((current) => current + halfPage)
 				return
 			}
-			if (plainKey && key.name === "o" && selectedPullRequest) {
+			if (matchesAction(key, "openInBrowser") && selectedPullRequest) {
 				openSelectedPullRequestInBrowser(selectedPullRequest)
 				return
 			}
-			if (plainKey && key.name === "y" && selectedPullRequest) {
+			if (matchesAction(key, "copyMetadata") && selectedPullRequest) {
 				copySelectedPullRequestMetadata()
 				return
 			}
@@ -1948,28 +1947,28 @@ export const App = () => {
 			}
 		}
 
-		if (key.name === "tab") {
+		if (matchesAction(key, "switchTab")) {
 			switchQueueMode(key.shift ? -1 : 1)
 			return
 		}
 
-		if (isThemeKey(key)) {
+		if (matchesAction(key, "openTheme")) {
 			openThemeModal()
 			return
 		}
 
-		if (key.name === "/") {
+		if (matchesAction(key, "filter")) {
 			setFilterDraft(filterQuery)
 			setFilterMode(true)
 			return
 		}
-		if (key.name === "escape" && filterQuery.length > 0) {
+		if (matchesAction(key, "clearFilter") && filterQuery.length > 0) {
 			setFilterQuery("")
 			setFilterDraft("")
 			setFilterMode(false)
 			return
 		}
-		if (key.name === "r") {
+		if (matchesAction(key, "refresh")) {
 			refreshPullRequests("Refreshed")
 			return
 		}
@@ -2033,36 +2032,36 @@ export const App = () => {
 			() => setSelectedIndex(0),
 			() => setSelectedIndex(visiblePullRequests.length === 0 ? 0 : visiblePullRequests.length - 1),
 		)) return
-		if ((key.name === "return" || key.name === "enter") && !detailFullView) {
+		if (matchesAction(key, "select") && !detailFullView) {
 			setDetailFullView(true)
 			setDetailScrollOffset(0)
 			return
 		}
-		if (key.name === "d" && selectedPullRequest) {
+		if (matchesAction(key, "openDiff") && selectedPullRequest) {
 			openDiffView()
 			return
 		}
-		if (key.name === "x" && selectedPullRequest?.state === "open") {
+		if (matchesAction(key, "close") && selectedPullRequest?.state === "open") {
 			openCloseModal()
 			return
 		}
-		if (key.name === "l" && selectedPullRequest) {
+		if (matchesAction(key, "labels") && selectedPullRequest) {
 			openLabelModal()
 			return
 		}
-		if (key.name === "m" || key.name === "M") {
+		if (matchesAction(key, "merge")) {
 			if (selectedPullRequest) openMergeModal()
 			return
 		}
-		if (key.name === "o" && selectedPullRequest) {
+		if (matchesAction(key, "openInBrowser") && selectedPullRequest) {
 			openSelectedPullRequestInBrowser(selectedPullRequest)
 			return
 		}
-		if ((key.name === "s" || key.name === "S") && selectedPullRequest) {
+		if (matchesAction(key, "toggleDraft") && selectedPullRequest) {
 			toggleSelectedPullRequestDraftStatus()
 			return
 		}
-		if (key.name === "y" && selectedPullRequest) {
+		if (matchesAction(key, "copyMetadata") && selectedPullRequest) {
 			copySelectedPullRequestMetadata()
 			return
 		}

--- a/src/configStore.ts
+++ b/src/configStore.ts
@@ -2,10 +2,12 @@ import { mkdir } from "node:fs/promises"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 import { Effect } from "effect"
+import { loadBindings, type Bindings } from "./keybindings.js"
 import { isThemeId, type ThemeId } from "./ui/colors.js"
 
 interface StoredConfig {
 	readonly theme?: unknown
+	readonly keybindings?: unknown
 }
 
 const configDirectory = () => {
@@ -22,13 +24,23 @@ const parseConfig = (text: string): StoredConfig => {
 	return value && typeof value === "object" ? value : {}
 }
 
-export const loadStoredThemeId: Effect.Effect<ThemeId> = Effect.catchCause(Effect.tryPromise(async () => {
+export interface StoredAppConfig {
+	readonly themeId: ThemeId
+	readonly bindings: Bindings
+}
+
+const defaultAppConfig: StoredAppConfig = { themeId: "ghui", bindings: loadBindings(undefined) }
+
+export const loadStoredConfig: Effect.Effect<StoredAppConfig> = Effect.catchCause(Effect.tryPromise(async () => {
 	const file = Bun.file(configPath())
-	if (!(await file.exists())) return "ghui" satisfies ThemeId
+	if (!(await file.exists())) return defaultAppConfig
 
 	const config = parseConfig(await file.text())
-	return isThemeId(config.theme) ? config.theme : "ghui"
-}), () => Effect.succeed("ghui" satisfies ThemeId))
+	return {
+		themeId: isThemeId(config.theme) ? config.theme : "ghui",
+		bindings: loadBindings(config.keybindings),
+	}
+}), () => Effect.succeed(defaultAppConfig))
 
 export const saveStoredThemeId = (theme: ThemeId): Effect.Effect<void> => Effect.tryPromise(async () => {
 	const path = configPath()

--- a/src/keybindings.ts
+++ b/src/keybindings.ts
@@ -1,0 +1,102 @@
+export type Action =
+	// Navigation
+	| "navigateUp"
+	| "navigateDown"
+	| "navigateGroupUp"
+	| "navigateGroupDown"
+	| "halfPageUp"
+	| "halfPageDown"
+	| "goToTop"
+	| "goToBottom"
+	// Selection & views
+	| "select"
+	| "back"
+	| "openDiff"
+	| "openInBrowser"
+	| "copyMetadata"
+	// PR operations
+	| "merge"
+	| "close"
+	| "toggleDraft"
+	| "labels"
+	| "refresh"
+	// List
+	| "filter"
+	| "clearFilter"
+	| "switchTab"
+	// Diff view
+	| "toggleDiffView"
+	| "toggleDiffWrap"
+	| "enterCommentMode"
+	| "jumpFileNext"
+	| "jumpFilePrev"
+	// Theme
+	| "openTheme"
+	// App
+	| "quit"
+
+export type KeyCombo = {
+	readonly key: string
+	readonly ctrl?: true
+	readonly shift?: true
+	readonly meta?: true
+}
+
+export type Binding = string | KeyCombo
+
+const ctrl = (name: string): KeyCombo => ({ key: name, ctrl: true })
+const shift = (name: string): KeyCombo => ({ key: name, shift: true })
+const meta = (name: string): KeyCombo => ({ key: name, meta: true })
+
+export const defaultBindings: Record<Action, readonly Binding[]> = {
+	navigateUp: ["up", "k"],
+	navigateDown: ["down", "j"],
+	navigateGroupUp: ["[", shift("k"), "K", meta("up"), meta("k")],
+	navigateGroupDown: ["]", shift("j"), "J", meta("down"), meta("j")],
+	halfPageUp: [ctrl("u")],
+	halfPageDown: [ctrl("d")],
+	goToTop: ["g"],
+	goToBottom: ["G"],
+	select: ["return", "enter"],
+	back: ["escape", "return", "enter"],
+	openDiff: ["d"],
+	openInBrowser: ["o"],
+	copyMetadata: ["y"],
+	merge: ["m", "M"],
+	close: ["x"],
+	toggleDraft: ["s", "S"],
+	labels: ["l"],
+	refresh: ["r"],
+	filter: ["/"],
+	clearFilter: ["escape"],
+	switchTab: ["tab"],
+	toggleDiffView: ["v"],
+	toggleDiffWrap: ["w"],
+	enterCommentMode: ["c"],
+	jumpFileNext: ["]", "right", "l"],
+	jumpFilePrev: ["[", "left", "h"],
+	openTheme: ["t", "T"],
+	quit: ["q", ctrl("c")],
+}
+
+type KeyEvent = {
+	readonly name: string
+	readonly ctrl?: boolean
+	readonly shift?: boolean
+	readonly meta?: boolean
+	readonly option?: boolean
+	readonly sequence: string
+}
+
+export const matchesAction = (key: KeyEvent, action: Action, bindings: Record<Action, readonly Binding[]> = defaultBindings): boolean => {
+	const candidates = bindings[action]
+	return candidates.some((binding) => {
+		if (typeof binding === "string") {
+			return key.name === binding && !key.ctrl && !key.meta && !key.option
+		}
+		return key.name === binding.key
+			&& (binding.ctrl ? !!key.ctrl : !key.ctrl)
+			&& (binding.shift ? !!(key.shift || key.name !== key.name.toLowerCase()) : true)
+			&& (binding.meta ? !!(key.meta || key.option) : !key.meta && !key.option)
+	})
+}

--- a/src/keybindings.ts
+++ b/src/keybindings.ts
@@ -88,7 +88,54 @@ type KeyEvent = {
 	readonly sequence: string
 }
 
-export const matchesAction = (key: KeyEvent, action: Action, bindings: Record<Action, readonly Binding[]> = defaultBindings): boolean => {
+export type Bindings = Record<Action, readonly Binding[]>
+
+const actions = new Set<Action>(Object.keys(defaultBindings) as Action[])
+const isAction = (value: unknown): value is Action => typeof value === "string" && actions.has(value as Action)
+
+const parseBinding = (raw: string): Binding => {
+	const parts = raw.toLowerCase().split("+")
+	const key = parts.pop()!
+	if (parts.length === 0) return raw
+	const combo: KeyCombo = { key } as KeyCombo
+	for (const mod of parts) {
+		if (mod === "ctrl") (combo as { ctrl: true }).ctrl = true
+		else if (mod === "shift") (combo as { shift: true }).shift = true
+		else if (mod === "meta" || mod === "alt" || mod === "opt" || mod === "option") (combo as { meta: true }).meta = true
+	}
+	return combo
+}
+
+export const loadBindings = (raw: unknown): Bindings => {
+	if (!raw || typeof raw !== "object") return defaultBindings
+	const overrides = raw as Record<string, unknown>
+	const result = { ...defaultBindings }
+	for (const [key, value] of Object.entries(overrides)) {
+		if (!isAction(key)) continue
+		const values = Array.isArray(value) ? value : [value]
+		const parsed = values.filter((v): v is string => typeof v === "string").map(parseBinding)
+		if (parsed.length > 0) result[key] = parsed
+	}
+	return result
+}
+
+export const formatBinding = (binding: Binding): string => {
+	if (typeof binding === "string") return binding
+	const parts: string[] = []
+	if (binding.ctrl) parts.push("ctrl")
+	if (binding.meta) parts.push("alt")
+	if (binding.shift) parts.push("shift")
+	parts.push(binding.key)
+	return parts.join("+")
+}
+
+export const hintLabel = (action: Action, bindings: Bindings = defaultBindings): string => {
+	const candidates = bindings[action]
+	if (candidates.length === 0) return "?"
+	return formatBinding(candidates[0]!)
+}
+
+export const matchesAction = (key: KeyEvent, action: Action, bindings: Bindings = defaultBindings): boolean => {
 	const candidates = bindings[action]
 	return candidates.some((binding) => {
 		if (typeof binding === "string") {

--- a/src/ui/FooterHints.tsx
+++ b/src/ui/FooterHints.tsx
@@ -1,3 +1,4 @@
+import type { Action } from "../keybindings.js"
 import { Data } from "effect"
 import { colors } from "./colors.js"
 import { TextLine } from "./primitives.js"
@@ -22,6 +23,7 @@ export const FooterHints = ({
 	isLoading,
 	loadingIndicator,
 	retryProgress,
+	hint,
 }: {
 	filterEditing: boolean
 	showFilterClear: boolean
@@ -34,6 +36,7 @@ export const FooterHints = ({
 	isLoading: boolean
 	loadingIndicator: string
 	retryProgress: RetryProgress
+	hint: (action: Action) => string
 }) => {
 	if (filterEditing) {
 		return (
@@ -64,36 +67,36 @@ export const FooterHints = ({
 					<span fg={colors.muted}> jump  </span>
 					<span fg={colors.count}>←→</span>
 					<span fg={colors.muted}> side  </span>
-					<span fg={colors.count}>enter</span>
+					<span fg={colors.count}>{hint("select")}</span>
 					<span fg={colors.muted}> open  </span>
 					<span fg={colors.count}>a</span>
 					<span fg={colors.muted}> comment  </span>
-					<span fg={colors.count}>c</span>
+					<span fg={colors.count}>{hint("enterCommentMode")}</span>
 					<span fg={colors.muted}> done  </span>
-					<span fg={colors.count}>[]</span>
+					<span fg={colors.count}>{hint("jumpFilePrev")}{hint("jumpFileNext")}</span>
 					<span fg={colors.muted}> files  </span>
-					<span fg={colors.count}>esc</span>
+					<span fg={colors.count}>{hint("back")}</span>
 					<span fg={colors.muted}> back</span>
 				</TextLine>
 			)
 		}
 		return (
 			<TextLine>
-				<span fg={colors.count}>esc</span>
+				<span fg={colors.count}>{hint("back")}</span>
 				<span fg={colors.muted}> back  </span>
-				<span fg={colors.count}>v</span>
+				<span fg={colors.count}>{hint("toggleDiffView")}</span>
 				<span fg={colors.muted}> view  </span>
-				<span fg={colors.count}>w</span>
+				<span fg={colors.count}>{hint("toggleDiffWrap")}</span>
 				<span fg={colors.muted}> wrap  </span>
-				<span fg={colors.count}>c</span>
+				<span fg={colors.count}>{hint("enterCommentMode")}</span>
 				<span fg={colors.muted}> comment  </span>
-				<span fg={colors.count}>[]</span>
+				<span fg={colors.count}>{hint("jumpFilePrev")}{hint("jumpFileNext")}</span>
 				<span fg={colors.muted}> files  </span>
-				<span fg={colors.count}>r</span>
+				<span fg={colors.count}>{hint("refresh")}</span>
 				<span fg={colors.muted}> reload  </span>
-				<span fg={colors.count}>o</span>
+				<span fg={colors.count}>{hint("openInBrowser")}</span>
 				<span fg={colors.muted}> open  </span>
-				<span fg={colors.count}>q</span>
+				<span fg={colors.count}>{hint("quit")}</span>
 				<span fg={colors.muted}> quit</span>
 			</TextLine>
 		)
@@ -102,37 +105,37 @@ export const FooterHints = ({
 	if (detailFullView) {
 		return (
 			<TextLine>
-				<span fg={colors.count}>esc</span>
+				<span fg={colors.count}>{hint("back")}</span>
 				<span fg={colors.muted}> back  </span>
 				<span fg={colors.count}>↑↓</span>
 				<span fg={colors.muted}> scroll  </span>
-				<span fg={colors.count}>r</span>
+				<span fg={colors.count}>{hint("refresh")}</span>
 				<span fg={colors.muted}>{hasError ? " retry  " : " refresh  "}</span>
-				<span fg={colors.count}>t</span>
+				<span fg={colors.count}>{hint("openTheme")}</span>
 				<span fg={colors.muted}> theme  </span>
 				{hasSelection ? (
 					<>
-						<span fg={colors.count}>s</span>
+						<span fg={colors.count}>{hint("toggleDraft")}</span>
 						<span fg={colors.muted}> state  </span>
-						<span fg={colors.count}>d</span>
+						<span fg={colors.count}>{hint("openDiff")}</span>
 						<span fg={colors.muted}> diff  </span>
-						<span fg={colors.count}>l</span>
+						<span fg={colors.count}>{hint("labels")}</span>
 						<span fg={colors.muted}> labels  </span>
-						<span fg={colors.count}>m</span>
+						<span fg={colors.count}>{hint("merge")}</span>
 						<span fg={colors.muted}> merge  </span>
 						{canCloseSelection ? (
 							<>
-								<span fg={colors.count}>x</span>
+								<span fg={colors.count}>{hint("close")}</span>
 								<span fg={colors.muted}> close  </span>
 							</>
 						) : null}
 					</>
 				) : null}
-				<span fg={colors.count}>o</span>
+				<span fg={colors.count}>{hint("openInBrowser")}</span>
 				<span fg={colors.muted}> open  </span>
-				<span fg={colors.count}>y</span>
+				<span fg={colors.count}>{hint("copyMetadata")}</span>
 				<span fg={colors.muted}> copy  </span>
-				<span fg={colors.count}>q</span>
+				<span fg={colors.count}>{hint("quit")}</span>
 				<span fg={colors.muted}> quit</span>
 			</TextLine>
 		)
@@ -140,15 +143,15 @@ export const FooterHints = ({
 
 	return (
 		<TextLine>
-			<span fg={colors.count}>tab</span>
+			<span fg={colors.count}>{hint("switchTab")}</span>
 			<span fg={colors.muted}> queue  </span>
-			<span fg={colors.count}>/</span>
+			<span fg={colors.count}>{hint("filter")}</span>
 			<span fg={colors.muted}> filter  </span>
-			<span fg={colors.count}>t</span>
+			<span fg={colors.count}>{hint("openTheme")}</span>
 			<span fg={colors.muted}> theme  </span>
 			{showFilterClear ? (
 				<>
-					<span fg={colors.count}>esc</span>
+					<span fg={colors.count}>{hint("clearFilter")}</span>
 					<span fg={colors.muted}> clear  </span>
 				</>
 			) : null}
@@ -163,31 +166,31 @@ export const FooterHints = ({
 					<span fg={colors.muted}> loading  </span>
 				</>
 			) : null}
-			<span fg={colors.count}>r</span>
+			<span fg={colors.count}>{hint("refresh")}</span>
 			<span fg={colors.muted}>{hasError ? " retry  " : " refresh  "}</span>
 			{hasSelection ? (
 				<>
-					<span fg={colors.count}>s</span>
+					<span fg={colors.count}>{hint("toggleDraft")}</span>
 					<span fg={colors.muted}> state  </span>
-					<span fg={colors.count}>d</span>
+					<span fg={colors.count}>{hint("openDiff")}</span>
 					<span fg={colors.muted}> diff  </span>
-					<span fg={colors.count}>l</span>
+					<span fg={colors.count}>{hint("labels")}</span>
 					<span fg={colors.muted}> labels  </span>
-					<span fg={colors.count}>m</span>
+					<span fg={colors.count}>{hint("merge")}</span>
 					<span fg={colors.muted}> merge  </span>
 					{canCloseSelection ? (
 						<>
-							<span fg={colors.count}>x</span>
+							<span fg={colors.count}>{hint("close")}</span>
 							<span fg={colors.muted}> close  </span>
 						</>
 					) : null}
-					<span fg={colors.count}>o</span>
+					<span fg={colors.count}>{hint("openInBrowser")}</span>
 					<span fg={colors.muted}> open  </span>
-					<span fg={colors.count}>y</span>
+					<span fg={colors.count}>{hint("copyMetadata")}</span>
 					<span fg={colors.muted}> copy  </span>
 				</>
 			) : null}
-			<span fg={colors.count}>q</span>
+			<span fg={colors.count}>{hint("quit")}</span>
 			<span fg={colors.muted}> quit</span>
 		</TextLine>
 	)


### PR DESCRIPTION
First of all, thanks for the program, I love it!

I know this is a bigger feature and that it might not go in the direction you want, and that is totally fine. Just close the PR.
I will also say that I did use AI tools for this feature, but I have reviewed it and tested it.

I find some of the semi destructive write actions is a bit too risky to have on a single key press. This was also mentioned in #4. To combat this I thought a good solution would be to let people just choose their own key bindings.

The way it works is that everywhere that before checked the key directly, it now matches the key against an action. This action corresponds to one or more key bindings. The other part of this is that the action map has a default and can be overwritten by a config file.

I hope this is useful!