### PR TITLE
feat: add pull request comments UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import type { DiffRenderable, ScrollBoxRenderable } from "@opentui/core"
+import { TextAttributes, type DiffRenderable, type ScrollBoxRenderable } from "@opentui/core"
 import { useAtom, useAtomRefresh, useAtomSet, useAtomValue } from "@effect/atom-react"
 import { useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/react"
 import { Cause, Effect, Layer, Schedule } from "effect"
@@ -6,24 +6,26 @@ import * as AsyncResult from "effect/unstable/reactivity/AsyncResult"
 import * as Atom from "effect/unstable/reactivity/Atom"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { config } from "./config.js"
-import { pullRequestQueueLabels, pullRequestQueueModes, type CreatePullRequestCommentInput, type DiffCommentSide, type LoadStatus, type PullRequestItem, type PullRequestLabel, type PullRequestMergeAction, type PullRequestQueueMode, type PullRequestReviewComment } from "./domain.js"
+import { pullRequestQueueLabels, pullRequestQueueModes, type CreatePullRequestCommentInput, type DiffCommentSide, type LoadStatus, pullRequestCommentKey, type PullRequestComment, type PullRequestItem, type PullRequestLabel, type PullRequestMergeAction, type PullRequestQueueMode, type PullRequestReviewComment } from "./domain.js"
 import { formatShortDate, formatTimestamp } from "./date.js"
 import { availableMergeActions, mergeInfoFromPullRequest } from "./mergeActions.js"
 import { Observability } from "./observability.js"
 import { GitHubService } from "./services/GitHubService.js"
+import { SqliteCacheService } from "./services/SqliteCacheService.js"
 import { loadStoredThemeId, saveStoredThemeId } from "./themeStore.js"
 import { colors, filterThemeDefinitions, setActiveTheme, themeDefinitions, type ThemeId } from "./ui/colors.js"
 import { backspace as editorBackspace, deleteForward as editorDeleteForward, deleteToLineEnd, deleteToLineStart, deleteWordBackward, deleteWordForward, insertText, moveLeft as editorMoveLeft, moveLineEnd, moveLineStart, moveRight as editorMoveRight, moveVertically, moveWordBackward, moveWordForward, type CommentEditorValue } from "./ui/commentEditor.js"
 import { buildStackedDiffFiles, diffCommentAnchorKey, diffCommentLocationKey, getStackedDiffCommentAnchors, nearestDiffCommentAnchorIndex, PullRequestDiffState, pullRequestDiffKey, safeDiffFileIndex, scrollTopForVisibleLine, splitPatchFiles, stackedDiffFileAtLine, type DiffCommentAnchor, type DiffView, type DiffWrapMode, type StackedDiffCommentAnchor } from "./ui/diff.js"
-import { DetailBody, DetailHeader, DetailPlaceholder, DetailsPane, getDetailBodyHeight, getDetailHeaderHeight, getDetailJunctionRows, getDetailsPaneHeight, LoadingPane, type DetailPlaceholderContent } from "./ui/DetailsPane.js"
+import { bodyPreview, DetailBody, DetailHeader, DetailPlaceholder, DetailsPane, getDetailBodyHeight, getDetailHeaderHeight, getDetailJunctionRows, getDetailsPaneHeight, LoadingPane, type DetailPlaceholderContent } from "./ui/DetailsPane.js"
 import { FooterHints, initialRetryProgress, RetryProgress } from "./ui/FooterHints.js"
-import { Divider, fitCell, PlainLine, SeparatorColumn } from "./ui/primitives.js"
+import { Divider, fitCell, PlainLine, SeparatorColumn, TextLine } from "./ui/primitives.js"
 import { CloseModal, CommentModal, CommentThreadModal, initialCloseModalState, initialCommentModalState, initialCommentThreadModalState, initialLabelModalState, initialMergeModalState, initialModal, initialThemeModalState, LabelModal, MergeModal, Modal, ThemeModal, type CloseModalState, type CommentModalState, type CommentThreadModalState, type LabelModalState, type MergeModalState, type ModalState, type ModalTag, type ThemeModalState } from "./ui/modals.js"
 import { groupBy, reviewLabel } from "./ui/pullRequests.js"
 import { PullRequestDiffPane } from "./ui/PullRequestDiffPane.js"
 import { PullRequestList } from "./ui/PullRequestList.js"
 
 const githubRuntime = Atom.runtime(GitHubService.layer.pipe(Layer.provideMerge(Observability.layer)))
+const sqliteCache = SqliteCacheService.open()
 const initialThemeId = await Effect.runPromise(loadStoredThemeId)
 
 
@@ -178,6 +180,9 @@ const getPullRequestDiffAtom = githubRuntime.fn<{ readonly repository: string; r
 const listPullRequestCommentsAtom = githubRuntime.fn<{ readonly repository: string; readonly number: number }>()((input) =>
 	GitHubService.use((github) => github.listPullRequestComments(input.repository, input.number))
 )
+const listPullRequestConversationCommentsAtom = githubRuntime.fn<{ readonly repository: string; readonly number: number }>()((input) =>
+	GitHubService.use((github) => github.listPullRequestConversationComments(input.repository, input.number))
+)
 const getPullRequestMergeInfoAtom = githubRuntime.fn<{ readonly repository: string; readonly number: number }>()((input) =>
 	GitHubService.use((github) => github.getPullRequestMergeInfo(input.repository, input.number))
 )
@@ -289,6 +294,38 @@ const copyPullRequestMetadata = async (pullRequest: PullRequestItem) => {
 const isShiftG = (key: { readonly name: string; readonly shift?: boolean }) => key.name === "G" || key.name === "g" && key.shift
 
 const isThemeKey = (key: { readonly name: string; readonly ctrl?: boolean; readonly meta?: boolean }) => !key.ctrl && !key.meta && key.name.toLowerCase() === "t"
+
+interface ConversationCommentState {
+	readonly status: "idle" | "loading" | "ready" | "error"
+	readonly comments: readonly PullRequestComment[]
+	readonly error: string | null
+}
+
+const isResolvedComment = (comment: PullRequestComment) => comment.context?.resolved === true
+
+const ConversationComment = ({ comment, contentWidth }: { comment: PullRequestComment; contentWidth: number }) => {
+	const context = comment.context ? ` ${comment.context.path}${comment.context.line ? `:${comment.context.line}` : ""}${isResolvedComment(comment) ? " resolved" : ""}` : ""
+	const suffix = ` ${formatShortDate(comment.createdAt)} ${formatTimestamp(comment.createdAt)}${context}`
+	const preview = bodyPreview(comment.body, Math.max(16, contentWidth - 4), 8)
+	return (
+		<box flexDirection="column">
+			<TextLine width={contentWidth}>
+				<span fg={colors.accent} attributes={TextAttributes.BOLD}>{comment.author}</span>
+				<span fg={colors.muted}>{fitCell(suffix, Math.max(0, contentWidth - comment.author.length))}</span>
+			</TextLine>
+			{preview.map((line, lineIndex) => (
+				<TextLine key={`${comment.id}-${lineIndex}`} width={contentWidth}>
+					<span fg={colors.muted}>  </span>
+					{line.segments.map((segment, segmentIndex) =>
+						segment.bold
+							? <span key={segmentIndex} fg={segment.fg} attributes={TextAttributes.BOLD}>{segment.text}</span>
+							: <span key={segmentIndex} fg={segment.fg}>{segment.text}</span>
+					)}
+				</TextLine>
+			))}
+		</box>
+	)
+}
 
 const nextQueueMode = (mode: PullRequestQueueMode, delta: 1 | -1) => {
 	const index = pullRequestQueueModes.indexOf(mode)
@@ -471,6 +508,7 @@ export const App = () => {
 	const [refreshCompletionMessage, setRefreshCompletionMessage] = useState<string | null>(null)
 	const [refreshStartedAt, setRefreshStartedAt] = useState<number | null>(null)
 	const [terminalFocused, setTerminalFocused] = useState(true)
+	const [conversationCommentsByKey, setConversationCommentsByKey] = useState<Record<string, ConversationCommentState>>({})
 	const usernameResult = useAtomValue(usernameAtom)
 	const loadRepoLabels = useAtomSet(listRepoLabelsAtom, { mode: "promise" })
 	const loadPullRequestDetails = useAtomSet(listOpenPullRequestDetailsAtom, { mode: "promise" })
@@ -479,6 +517,7 @@ export const App = () => {
 	const toggleDraftStatus = useAtomSet(toggleDraftAtom, { mode: "promise" })
 	const getPullRequestDiff = useAtomSet(getPullRequestDiffAtom, { mode: "promise" })
 	const listPullRequestComments = useAtomSet(listPullRequestCommentsAtom, { mode: "promise" })
+	const listPullRequestConversationComments = useAtomSet(listPullRequestConversationCommentsAtom, { mode: "promise" })
 	const getPullRequestMergeInfo = useAtomSet(getPullRequestMergeInfoAtom, { mode: "promise" })
 	const mergePullRequest = useAtomSet(mergePullRequestAtom, { mode: "promise" })
 	const closePullRequest = useAtomSet(closePullRequestAtom, { mode: "promise" })
@@ -589,6 +628,8 @@ export const App = () => {
 	)
 	const visiblePullRequests = useMemo(() => visibleGroups.flatMap(([, pullRequests]) => pullRequests), [visibleGroups])
 	const selectedPullRequest = visiblePullRequests[selectedIndex] ?? null
+	const selectedConversationKey = selectedPullRequest ? pullRequestCommentKey(selectedPullRequest) : null
+	const selectedConversationState = selectedConversationKey ? conversationCommentsByKey[selectedConversationKey] ?? { status: "idle", comments: [], error: null } : { status: "idle", comments: [], error: null }
 	const selectedDiffState = selectedPullRequest ? pullRequestDiffCache[pullRequestDiffKey(selectedPullRequest)] : undefined
 	const effectiveDiffRenderView = contentWidth >= 100 ? diffRenderView : "unified"
 	const readyDiffFiles = selectedDiffState?._tag === "Ready" ? selectedDiffState.files : []
@@ -755,6 +796,32 @@ export const App = () => {
 		setDiffScrollTop(0)
 		setDiffCommentAnchorIndex(0)
 	}, [selectedIndex])
+
+
+	useEffect(() => {
+		if (!selectedPullRequest || !selectedConversationKey) return
+		const { repository, number } = selectedPullRequest
+		const cachedComments = sqliteCache?.readComments(repository, number) ?? null
+		setConversationCommentsByKey((current) => current[selectedConversationKey]
+			? current
+			: { ...current, [selectedConversationKey]: { status: cachedComments ? "ready" : "loading", comments: cachedComments ?? [], error: null } })
+		let cancelled = false
+		void listPullRequestConversationComments({ repository, number })
+			.then((comments) => {
+				if (cancelled) return
+				setConversationCommentsByKey((current) => ({ ...current, [selectedConversationKey]: { status: "ready", comments, error: null } }))
+				sqliteCache?.writeComments(repository, number, comments)
+			})
+			.catch((error) => {
+				if (cancelled) return
+				const message = errorMessage(error)
+				setConversationCommentsByKey((current) => ({
+					...current,
+					[selectedConversationKey]: { status: "error", comments: current[selectedConversationKey]?.comments ?? cachedComments ?? [], error: message },
+				}))
+			})
+		return () => { cancelled = true }
+	}, [selectedConversationKey, selectedPullRequest?.url])
 
 	useEffect(() => {
 		setDiffCommentAnchorIndex((current) => {
@@ -2086,6 +2153,8 @@ export const App = () => {
 	const wideDetailHeaderHeight = getDetailHeaderHeight(selectedPullRequest, rightPaneWidth, true)
 	const wideDetailBodyViewportHeight = Math.max(1, wideBodyHeight - wideDetailHeaderHeight)
 	const wideDetailBodyScrollable = getDetailBodyHeight(selectedPullRequest, rightContentWidth, wideDetailLines) > wideDetailBodyViewportHeight
+	const commentsPaneHeight = Math.max(4, Math.floor(wideBodyHeight * 0.35))
+	const commentsVisible = selectedConversationState.status !== "idle" || selectedConversationState.comments.length > 0
 
 	const prListProps = {
 		groups: visibleGroups,
@@ -2189,6 +2258,19 @@ export const App = () => {
 								<scrollbox flexGrow={1} verticalScrollbarOptions={{ visible: wideDetailBodyScrollable }}>
 									<DetailBody pullRequest={selectedPullRequest} contentWidth={rightContentWidth} bodyLines={wideDetailLines} loadingIndicator={loadingIndicator} themeId={themeId} />
 								</scrollbox>
+								{commentsVisible ? (
+									<>
+										<Divider width={rightPaneWidth} />
+										<box height={commentsPaneHeight} flexDirection="column" paddingLeft={sectionPadding} paddingRight={sectionPadding}>
+											<PlainLine text={fitCell(selectedConversationState.status === "loading" ? `${loadingIndicator} Comments` : `Comments ${selectedConversationState.comments.length}`, rightContentWidth)} fg={colors.count} bold />
+											{selectedConversationState.status === "error" ? <PlainLine text={fitCell(selectedConversationState.error ?? "Could not load comments", rightContentWidth)} fg={colors.error} /> : null}
+											{selectedConversationState.status !== "loading" && selectedConversationState.comments.length === 0 ? <PlainLine text={fitCell("No conversation comments", rightContentWidth)} fg={colors.muted} /> : null}
+											<scrollbox flexGrow={1}>
+												{selectedConversationState.comments.map((comment) => <ConversationComment key={`${selectedConversationKey}:${comment.id}`} comment={comment} contentWidth={rightContentWidth} />)}
+											</scrollbox>
+										</box>
+									</>
+								) : null}
 							</>
 						) : (
 							<DetailPlaceholder content={detailPlaceholderContent} paneWidth={rightPaneWidth} />

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,11 @@ import { Config, Effect } from "effect"
 
 const positiveIntOr = (fallback: number) => (value: number) => Number.isFinite(value) && value > 0 ? value : fallback
 
+const defaultCachePath = () => {
+	const base = process.env.XDG_CACHE_HOME?.trim() || `${process.env.HOME ?? "."}/.cache`
+	return `${base}/ghui/cache.sqlite`
+}
+
 const appConfig = Config.all({
 	author: Config.string("GHUI_AUTHOR").pipe(
 		Config.withDefault("@me"),
@@ -10,6 +15,10 @@ const appConfig = Config.all({
 	prFetchLimit: Config.int("GHUI_PR_FETCH_LIMIT").pipe(
 		Config.withDefault(200),
 		Config.map(positiveIntOr(200)),
+	),
+	cachePath: Config.string("GHUI_CACHE_PATH").pipe(
+		Config.withDefault(defaultCachePath()),
+		Config.map((value) => value.trim() || defaultCachePath()),
 	),
 })
 

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -115,3 +115,32 @@ export interface PullRequestMergeInfo {
 	readonly checkSummary: string | null
 	readonly autoMergeEnabled: boolean
 }
+
+export type PullRequestCommentKey = `${string}#${number}`
+
+export const pullRequestCommentKey = (pullRequest: Pick<PullRequestItem, "repository" | "number">): PullRequestCommentKey =>
+	`${pullRequest.repository}#${pullRequest.number}`
+
+export type PullRequestCommentKind = "issue" | "thread"
+
+export interface PullRequestCommentContext {
+	readonly path: string
+	readonly line: number | null
+	readonly originalLine: number | null
+	readonly resolved?: boolean | null
+}
+
+export interface PullRequestComment {
+	readonly id: string
+	readonly databaseId: number | null
+	readonly kind: PullRequestCommentKind
+	readonly author: string
+	readonly body: string
+	readonly createdAt: Date
+	readonly updatedAt: Date
+	readonly htmlUrl: string
+	readonly context: PullRequestCommentContext | null
+	readonly threadId: string | null
+	readonly parentId: string | null
+	readonly depth: number
+}

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -1,6 +1,6 @@
 import { Context, Effect, Layer, Schema } from "effect"
 import { config } from "../config.js"
-import { DiffCommentSide, pullRequestQueueSearchQualifier, type CheckItem, type CreatePullRequestCommentInput, type Mergeable, type PullRequestItem, type PullRequestMergeAction, type PullRequestMergeInfo, type PullRequestQueueMode, type PullRequestReviewComment, type ReviewStatus } from "../domain.js"
+import { DiffCommentSide, pullRequestQueueSearchQualifier, type CheckItem, type CreatePullRequestCommentInput, type Mergeable, type PullRequestComment, type PullRequestItem, type PullRequestMergeAction, type PullRequestMergeInfo, type PullRequestQueueMode, type PullRequestReviewComment, type ReviewStatus } from "../domain.js"
 import { getMergeActionDefinition } from "../mergeActions.js"
 import { CommandRunner, type CommandError, type JsonParseError } from "./CommandRunner.js"
 
@@ -168,6 +168,47 @@ query PullRequests($searchQuery: String!, $first: Int!, $after: String) {
   }
 }
 `
+
+interface GitHubIssueComment {
+	readonly id: number
+	readonly user?: { readonly login?: string | null } | null
+	readonly body?: string | null
+	readonly created_at: string
+	readonly updated_at: string
+	readonly html_url: string
+}
+
+interface GitHubReviewThreadsResponse {
+	readonly data?: {
+		readonly repository?: {
+			readonly pullRequest?: {
+				readonly reviewThreads?: {
+					readonly nodes?: readonly GitHubReviewThread[] | null
+				} | null
+			} | null
+		} | null
+	} | null
+}
+
+interface GitHubReviewThread {
+	readonly id: string
+	readonly isResolved?: boolean | null
+	readonly comments?: { readonly nodes?: readonly GitHubThreadComment[] | null } | null
+}
+
+interface GitHubThreadComment {
+	readonly id: string
+	readonly databaseId?: number | null
+	readonly author?: { readonly login?: string | null } | null
+	readonly body?: string | null
+	readonly createdAt: string
+	readonly updatedAt: string
+	readonly url: string
+	readonly path?: string | null
+	readonly line?: number | null
+	readonly originalLine?: number | null
+	readonly replyTo?: { readonly id?: string | null } | null
+}
 
 const pullRequestSummarySearchQuery = `
 query PullRequests($searchQuery: String!, $first: Int!, $after: String) {
@@ -343,6 +384,62 @@ const searchQuery = (mode: PullRequestQueueMode, author: string) => `${pullReque
 const sortNewestFirst = (pullRequests: readonly PullRequestItem[]) =>
 	[...pullRequests].sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime())
 
+const parseIssueComment = (comment: GitHubIssueComment): PullRequestComment => ({
+	id: `issue:${comment.id}`,
+	databaseId: comment.id,
+	kind: "issue",
+	author: comment.user?.login ?? "unknown",
+	body: comment.body ?? "",
+	createdAt: new Date(comment.created_at),
+	updatedAt: new Date(comment.updated_at),
+	htmlUrl: comment.html_url,
+	context: null,
+	threadId: null,
+	parentId: null,
+	depth: 0,
+})
+
+const parseThreadComment = (thread: GitHubReviewThread, comment: GitHubThreadComment, index: number): PullRequestComment => ({
+	id: `thread:${comment.id}`,
+	databaseId: comment.databaseId ?? null,
+	kind: "thread",
+	author: comment.author?.login ?? "unknown",
+	body: comment.body ?? "",
+	createdAt: new Date(comment.createdAt),
+	updatedAt: new Date(comment.updatedAt),
+	htmlUrl: comment.url,
+	context: comment.path
+		? { path: comment.path, line: comment.line ?? null, originalLine: comment.originalLine ?? null, resolved: thread.isResolved ?? null }
+		: null,
+	threadId: thread.id,
+	parentId: comment.replyTo?.id ? `thread:${comment.replyTo.id}` : null,
+	depth: index === 0 ? 0 : 1,
+})
+
+const mergeComments = (comments: readonly PullRequestComment[]) => {
+	const byKey = new Map<string, PullRequestComment>()
+	for (const comment of comments) {
+		// REST review comments and GraphQL review-thread comments can overlap.
+		// Use databaseId when present so the same GitHub comment is rendered once.
+		const key = comment.databaseId ? `db:${comment.databaseId}` : comment.id
+		if (!byKey.has(key)) byKey.set(key, comment)
+	}
+
+	const groups = new Map<string, PullRequestComment[]>()
+	for (const comment of byKey.values()) {
+		const key = comment.threadId ?? comment.id
+		groups.set(key, [...(groups.get(key) ?? []), comment])
+	}
+
+	return [...groups.values()]
+		.map((group) => group.sort((left, right) => {
+			if (left.depth !== right.depth) return left.depth - right.depth
+			return left.createdAt.getTime() - right.createdAt.getTime()
+		}))
+		.sort((left, right) => left[0]!.createdAt.getTime() - right[0]!.createdAt.getTime())
+		.flat()
+}
+
 const parsePullRequestComment = (comment: RawPullRequestComment): PullRequestReviewComment | null => {
 	const line = comment.line ?? comment.original_line
 	if (!comment.path || !line || (comment.side !== "LEFT" && comment.side !== "RIGHT")) return null
@@ -399,6 +496,7 @@ export class GitHubService extends Context.Service<GitHubService, {
 	readonly mergePullRequest: (repository: string, number: number, action: PullRequestMergeAction) => Effect.Effect<void, CommandError>
 	readonly closePullRequest: (repository: string, number: number) => Effect.Effect<void, CommandError>
 	readonly createPullRequestComment: (input: CreatePullRequestCommentInput) => Effect.Effect<PullRequestReviewComment, GitHubError>
+	readonly listPullRequestConversationComments: (repository: string, number: number) => Effect.Effect<readonly PullRequestComment[], GitHubError>
 	readonly toggleDraftStatus: (repository: string, number: number, isDraft: boolean) => Effect.Effect<void, CommandError>
 	readonly listRepoLabels: (repository: string) => Effect.Effect<readonly { readonly name: string; readonly color: string | null }[], GitHubError>
 	readonly addPullRequestLabel: (repository: string, number: number, label: string) => Effect.Effect<void, CommandError>
@@ -504,6 +602,30 @@ export class GitHubService extends Context.Service<GitHubService, {
 				yield* command.run("gh", ["pr", "ready", String(number), "--repo", repository, ...(isDraft ? [] : ["--undo"])])
 			})
 
+			const listPullRequestConversationComments = Effect.fn("GitHubService.listPullRequestConversationComments")(function*(repository: string, number: number) {
+				const [owner, name] = repository.split("/")
+				const comments = yield* command.runJson<readonly GitHubIssueComment[]>("gh", [
+					"api", `repos/${repository}/issues/${number}/comments`, "--paginate",
+				])
+				let reviewThreads: GitHubReviewThreadsResponse = {}
+				if (owner && name) {
+					reviewThreads = yield* command.runJson<GitHubReviewThreadsResponse>("gh", [
+						"api", "graphql",
+						"-f", "query=query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100){nodes{id isResolved comments(first:100){nodes{id databaseId author{login} body createdAt updatedAt url path line originalLine replyTo{id}}}}}}}}",
+						"-F", `owner=${owner}`,
+						"-F", `name=${name}`,
+						"-F", `number=${number}`,
+					]).pipe(Effect.catch(() => Effect.succeed({} as GitHubReviewThreadsResponse)))
+				}
+				const threadComments = reviewThreads.data?.repository?.pullRequest?.reviewThreads?.nodes?.flatMap((thread) =>
+					(thread.comments?.nodes ?? []).map((comment, index) => parseThreadComment(thread, comment, index)),
+				) ?? []
+				return mergeComments([
+					...comments.map(parseIssueComment),
+					...threadComments,
+				])
+			})
+
 			const listRepoLabels = Effect.fn("GitHubService.listRepoLabels")(function*(repository: string) {
 				const labels = yield* command.runSchema(RepoLabelsResponseSchema, "gh", [
 					"label", "list", "--repo", repository, "--json", "name,color", "--limit", "100",
@@ -529,6 +651,7 @@ export class GitHubService extends Context.Service<GitHubService, {
 				mergePullRequest,
 				closePullRequest,
 				createPullRequestComment,
+				listPullRequestConversationComments,
 				toggleDraftStatus,
 				listRepoLabels,
 				addPullRequestLabel,

--- a/src/services/SqliteCacheService.ts
+++ b/src/services/SqliteCacheService.ts
@@ -1,0 +1,67 @@
+import { Database } from "bun:sqlite"
+import { mkdirSync } from "node:fs"
+import { dirname } from "node:path"
+import { config } from "../config.js"
+import type { PullRequestItem } from "../domain.js"
+
+const SCHEMA_VERSION = 1
+
+interface PrRow { readonly data: string }
+interface VersionRow { readonly value: string }
+
+const parsePullRequest = (data: string): PullRequestItem => {
+	const raw = JSON.parse(data) as PullRequestItem & { readonly createdAt: string; readonly closedAt: string | null }
+	return { ...raw, createdAt: new Date(raw.createdAt), closedAt: raw.closedAt ? new Date(raw.closedAt) : null }
+}
+
+export class SqliteCacheService {
+	private readonly db: Database
+
+	private constructor(path: string) {
+		mkdirSync(dirname(path), { recursive: true })
+		this.db = new Database(path)
+		this.migrate()
+	}
+
+	static open(path = config.cachePath): SqliteCacheService | null {
+		try {
+			return new SqliteCacheService(path)
+		} catch {
+			return null
+		}
+	}
+
+	readPullRequests(scope = config.author): readonly PullRequestItem[] {
+		try {
+			const rows = this.db.query<PrRow, [string]>("select data from pull_requests where scope = ? order by created_at desc").all(scope)
+			return rows.map((row) => parsePullRequest(row.data))
+		} catch {
+			return []
+		}
+	}
+
+	writePullRequests(items: readonly PullRequestItem[], scope = config.author): void {
+		try {
+			const transaction = this.db.transaction((pullRequests: readonly PullRequestItem[]) => {
+				this.db.query("delete from pull_requests where scope = ?").run(scope)
+				const insert = this.db.query("insert into pull_requests (scope, repository, number, created_at, data) values (?, ?, ?, ?, ?)")
+				for (const pr of pullRequests) {
+					insert.run(scope, pr.repository, pr.number, pr.createdAt.toISOString(), JSON.stringify(pr))
+				}
+			})
+			transaction(items)
+		} catch {
+			// Cache writes should never interrupt UI updates.
+		}
+	}
+
+	private migrate(): void {
+		this.db.run("create table if not exists cache_meta (key text primary key, value text not null)")
+		const version = this.db.query<VersionRow, []>("select value from cache_meta where key = 'schema_version'").get()
+		if (version && Number(version.value) !== SCHEMA_VERSION) {
+			this.db.run("drop table if exists pull_requests")
+		}
+		this.db.run("create table if not exists pull_requests (scope text not null, repository text not null, number integer not null, created_at text not null, data text not null, primary key (scope, repository, number))")
+		this.db.run("insert into cache_meta (key, value) values ('schema_version', ?) on conflict(key) do update set value = excluded.value", [String(SCHEMA_VERSION)])
+	}
+}

--- a/src/services/SqliteCacheService.ts
+++ b/src/services/SqliteCacheService.ts
@@ -2,16 +2,22 @@ import { Database } from "bun:sqlite"
 import { mkdirSync } from "node:fs"
 import { dirname } from "node:path"
 import { config } from "../config.js"
-import type { PullRequestItem } from "../domain.js"
+import type { PullRequestComment, PullRequestItem } from "../domain.js"
 
-const SCHEMA_VERSION = 1
+const SCHEMA_VERSION = 2
 
 interface PrRow { readonly data: string }
+interface CommentRow { readonly data: string }
 interface VersionRow { readonly value: string }
 
 const parsePullRequest = (data: string): PullRequestItem => {
 	const raw = JSON.parse(data) as PullRequestItem & { readonly createdAt: string; readonly closedAt: string | null }
 	return { ...raw, createdAt: new Date(raw.createdAt), closedAt: raw.closedAt ? new Date(raw.closedAt) : null }
+}
+
+const parseComment = (data: string): PullRequestComment => {
+	const raw = JSON.parse(data) as PullRequestComment & { readonly createdAt: string; readonly updatedAt: string }
+	return { ...raw, createdAt: new Date(raw.createdAt), updatedAt: new Date(raw.updatedAt) }
 }
 
 export class SqliteCacheService {
@@ -55,13 +61,39 @@ export class SqliteCacheService {
 		}
 	}
 
+	readComments(repository: string, number: number, scope = config.author): readonly PullRequestComment[] | null {
+		try {
+			const rows = this.db.query<CommentRow, [string, string, number]>("select data from pull_request_comments where scope = ? and repository = ? and number = ? order by position asc").all(scope, repository, number)
+			return rows.length > 0 ? rows.map((row) => parseComment(row.data)) : null
+		} catch {
+			return null
+		}
+	}
+
+	writeComments(repository: string, number: number, comments: readonly PullRequestComment[], scope = config.author): void {
+		try {
+			const transaction = this.db.transaction((items: readonly PullRequestComment[]) => {
+				this.db.query("delete from pull_request_comments where scope = ? and repository = ? and number = ?").run(scope, repository, number)
+				const insert = this.db.query("insert into pull_request_comments (scope, repository, number, id, position, created_at, data) values (?, ?, ?, ?, ?, ?, ?)")
+				for (const [index, comment] of items.entries()) {
+					insert.run(scope, repository, number, comment.id, index, comment.createdAt.toISOString(), JSON.stringify(comment))
+				}
+			})
+			transaction(comments)
+		} catch {
+			// Cache writes should never interrupt UI updates.
+		}
+	}
+
 	private migrate(): void {
 		this.db.run("create table if not exists cache_meta (key text primary key, value text not null)")
 		const version = this.db.query<VersionRow, []>("select value from cache_meta where key = 'schema_version'").get()
 		if (version && Number(version.value) !== SCHEMA_VERSION) {
 			this.db.run("drop table if exists pull_requests")
+			this.db.run("drop table if exists pull_request_comments")
 		}
 		this.db.run("create table if not exists pull_requests (scope text not null, repository text not null, number integer not null, created_at text not null, data text not null, primary key (scope, repository, number))")
+		this.db.run("create table if not exists pull_request_comments (scope text not null, repository text not null, number integer not null, id text not null, position integer not null, created_at text not null, data text not null, primary key (scope, repository, number, id))")
 		this.db.run("insert into cache_meta (key, value) values ('schema_version', ?) on conflict(key) do update set value = excluded.value", [String(SCHEMA_VERSION)])
 	}
 }

--- a/src/ui/DetailsPane.tsx
+++ b/src/ui/DetailsPane.tsx
@@ -7,7 +7,7 @@ import { diffStatText } from "./diff.js"
 import { centerCell, Divider, fitCell, PlainLine, TextLine } from "./primitives.js"
 import { labelColor, labelTextColor, reviewLabel, shortRepoName, statusColor } from "./pullRequests.js"
 
-interface PreviewLine {
+export interface PreviewLine {
 	readonly segments: ReadonlyArray<{
 		readonly text: string
 		readonly fg: string
@@ -92,7 +92,7 @@ const wrapPreviewSegments = (segments: PreviewLine["segments"], width: number, i
 	return lines
 }
 
-const bodyPreview = (body: string, width: number, limit = DETAIL_BODY_LINES): Array<PreviewLine> => {
+export const bodyPreview = (body: string, width: number, limit = DETAIL_BODY_LINES): Array<PreviewLine> => {
 	const sourceLines = body.replace(/\r/g, "").split("\n")
 	const preview: Array<PreviewLine> = []
 	let inCodeBlock = false


### PR DESCRIPTION
## Summary
- Add PR conversation comments to the details pane.
- Fetch conversation comments via GitHub CLI and cache them in SQLite by repository + PR number.
- Render comments from selected-PR keyed state so comments cannot leak between PRs during rapid navigation.

## Dependency
- Depends on #16 (SQLite cache backend).
- This branch is currently stacked on top of `feature/sqlite-cache-backend`; please review/merge #16 first.

## Testing
- bun test test
- bun run typecheck
