### PR TITLE
feat: support all available merge methods

### DIFF
--- a/src/domain.ts
+++ b/src/domain.ts
@@ -43,7 +43,22 @@ export type Mergeable = "mergeable" | "conflicting" | "unknown"
 export const DiffCommentSide = Schema.Literals(["LEFT", "RIGHT"])
 export type DiffCommentSide = Schema.Schema.Type<typeof DiffCommentSide>
 
-export type PullRequestMergeAction = "squash" | "auto" | "admin" | "disable-auto"
+export const PullRequestMergeMethod = Schema.Literals(["merge", "squash", "rebase"])
+export type PullRequestMergeMethod = Schema.Schema.Type<typeof PullRequestMergeMethod>
+
+export const PullRequestMergeAction = Schema.Literals([
+	"merge",
+	"squash",
+	"rebase",
+	"auto-merge",
+	"auto-squash",
+	"auto-rebase",
+	"admin-merge",
+	"admin-squash",
+	"admin-rebase",
+	"disable-auto",
+])
+export type PullRequestMergeAction = Schema.Schema.Type<typeof PullRequestMergeAction>
 
 export const pullRequestReviewEvents = ["COMMENT", "APPROVE", "REQUEST_CHANGES"] as const
 export type PullRequestReviewEvent = (typeof pullRequestReviewEvents)[number]
@@ -147,4 +162,6 @@ export interface PullRequestMergeInfo {
 	readonly checkStatus: CheckRollupStatus
 	readonly checkSummary: string | null
 	readonly autoMergeEnabled: boolean
+	readonly viewerCanMergeAsAdmin: boolean
+	readonly allowedMethods: readonly PullRequestMergeMethod[]
 }

--- a/src/mergeActions.ts
+++ b/src/mergeActions.ts
@@ -1,4 +1,4 @@
-import type { PullRequestItem, PullRequestMergeAction, PullRequestMergeInfo, PullRequestState } from "./domain.js"
+import type { PullRequestItem, PullRequestMergeAction, PullRequestMergeInfo, PullRequestMergeMethod, PullRequestState } from "./domain.js"
 
 export interface MergeActionDefinition {
 	readonly action: PullRequestMergeAction
@@ -22,7 +22,19 @@ const isCleanlyMergeable = (info: PullRequestMergeInfo) =>
 	info.checkStatus !== "pending" &&
 	info.checkStatus !== "failing"
 
+const allowsMethod = (info: PullRequestMergeInfo, method: PullRequestMergeMethod) =>
+	info.allowedMethods.includes(method)
+
 const mergeActionDefinitions = {
+	merge: {
+		action: "merge",
+		title: "Merge now",
+		description: "Create a merge commit and delete the branch.",
+		cliArgs: ["--merge", "--delete-branch"],
+		pastTense: "Merged",
+		refreshOnSuccess: true,
+		isAvailable: (info) => isCleanlyMergeable(info) && allowsMethod(info, "merge"),
+	},
 	squash: {
 		action: "squash",
 		title: "Squash merge now",
@@ -31,16 +43,58 @@ const mergeActionDefinitions = {
 		pastTense: "Merged",
 		refreshOnSuccess: true,
 		optimisticState: "merged",
-		isAvailable: isCleanlyMergeable,
+		isAvailable: (info) => isCleanlyMergeable(info) && allowsMethod(info, "squash"),
 	},
-	auto: {
-		action: "auto",
+	rebase: {
+		action: "rebase",
+		title: "Rebase merge now",
+		description: "Rebase onto the base branch and delete the branch.",
+		cliArgs: ["--rebase", "--delete-branch"],
+		pastTense: "Merged",
+		refreshOnSuccess: true,
+		isAvailable: (info) => isCleanlyMergeable(info) && allowsMethod(info, "rebase"),
+	},
+	"auto-merge": {
+		action: "auto-merge",
 		title: "Enable auto-merge",
+		description: "Merge automatically after GitHub requirements pass.",
+		cliArgs: ["--merge", "--auto", "--delete-branch"],
+		pastTense: "Enabled auto-merge",
+		optimisticAutoMergeEnabled: true,
+		isAvailable: (info) =>
+			info.state === "open" &&
+			!info.autoMergeEnabled &&
+			!info.isDraft &&
+			info.mergeable !== "conflicting" &&
+			allowsMethod(info, "merge"),
+	},
+	"auto-squash": {
+		action: "auto-squash",
+		title: "Enable auto-squash",
 		description: "Squash merge automatically after GitHub requirements pass.",
 		cliArgs: ["--squash", "--auto", "--delete-branch"],
 		pastTense: "Enabled auto-merge",
 		optimisticAutoMergeEnabled: true,
-		isAvailable: (info) => info.state === "open" && !info.autoMergeEnabled && !info.isDraft && info.mergeable !== "conflicting",
+		isAvailable: (info) =>
+			info.state === "open" &&
+			!info.autoMergeEnabled &&
+			!info.isDraft &&
+			info.mergeable !== "conflicting" &&
+			allowsMethod(info, "squash"),
+	},
+	"auto-rebase": {
+		action: "auto-rebase",
+		title: "Enable auto-rebase",
+		description: "Rebase merge automatically after GitHub requirements pass.",
+		cliArgs: ["--rebase", "--auto", "--delete-branch"],
+		pastTense: "Enabled auto-merge",
+		optimisticAutoMergeEnabled: true,
+		isAvailable: (info) =>
+			info.state === "open" &&
+			!info.autoMergeEnabled &&
+			!info.isDraft &&
+			info.mergeable !== "conflicting" &&
+			allowsMethod(info, "rebase"),
 	},
 	"disable-auto": {
 		action: "disable-auto",
@@ -51,16 +105,51 @@ const mergeActionDefinitions = {
 		optimisticAutoMergeEnabled: false,
 		isAvailable: (info) => info.state === "open" && info.autoMergeEnabled,
 	},
-	admin: {
-		action: "admin",
+	"admin-merge": {
+		action: "admin-merge",
 		title: "Admin override merge",
-		description: "Bypass unmet merge requirements with --admin.",
+		description: "Bypass unmet merge requirements with a merge commit.",
+		cliArgs: ["--merge", "--admin", "--delete-branch"],
+		pastTense: "Admin merged",
+		danger: true,
+		refreshOnSuccess: true,
+		isAvailable: (info) =>
+			info.viewerCanMergeAsAdmin &&
+			info.state === "open" &&
+			!info.isDraft &&
+			info.mergeable !== "conflicting" &&
+			allowsMethod(info, "merge"),
+	},
+	"admin-squash": {
+		action: "admin-squash",
+		title: "Admin override squash",
+		description: "Bypass unmet merge requirements with a squash merge.",
 		cliArgs: ["--squash", "--admin", "--delete-branch"],
 		pastTense: "Admin merged",
 		danger: true,
 		refreshOnSuccess: true,
 		optimisticState: "merged",
-		isAvailable: (info) => info.state === "open" && !info.isDraft && info.mergeable !== "conflicting",
+		isAvailable: (info) =>
+			info.viewerCanMergeAsAdmin &&
+			info.state === "open" &&
+			!info.isDraft &&
+			info.mergeable !== "conflicting" &&
+			allowsMethod(info, "squash"),
+	},
+	"admin-rebase": {
+		action: "admin-rebase",
+		title: "Admin override rebase",
+		description: "Bypass unmet merge requirements with a rebase merge.",
+		cliArgs: ["--rebase", "--admin", "--delete-branch"],
+		pastTense: "Admin merged",
+		danger: true,
+		refreshOnSuccess: true,
+		isAvailable: (info) =>
+			info.viewerCanMergeAsAdmin &&
+			info.state === "open" &&
+			!info.isDraft &&
+			info.mergeable !== "conflicting" &&
+			allowsMethod(info, "rebase"),
 	},
 } as const satisfies Record<PullRequestMergeAction, MergeActionDefinition>
 
@@ -84,4 +173,6 @@ export const mergeInfoFromPullRequest = (pullRequest: PullRequestItem): PullRequ
 	checkStatus: pullRequest.checkStatus,
 	checkSummary: pullRequest.checkSummary,
 	autoMergeEnabled: pullRequest.autoMergeEnabled,
+	viewerCanMergeAsAdmin: false,
+	allowedMethods: ["merge", "squash", "rebase"],
 })

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -11,6 +11,7 @@ import {
 	type PullRequestItem,
 	type PullRequestMergeAction,
 	type PullRequestMergeInfo,
+	type PullRequestMergeMethod,
 	type PullRequestPage,
 	type PullRequestQueueMode,
 	type PullRequestReviewComment,
@@ -128,6 +129,10 @@ const MergeInfoResponseSchema = Schema.Struct({
 	mergeable: Schema.String,
 	reviewDecision: NullableString,
 	autoMergeRequest: Schema.NullOr(Schema.Unknown),
+	viewerCanMergeAsAdmin: Schema.Boolean,
+	mergeCommitAllowed: Schema.Boolean,
+	squashMergeAllowed: Schema.Boolean,
+	rebaseMergeAllowed: Schema.Boolean,
 	statusCheckRollup: Schema.Array(RawCheckContextSchema),
 })
 
@@ -543,6 +548,18 @@ const REVIEW_EVENT_CLI_FLAG = {
 	REQUEST_CHANGES: "--request-changes",
 } as const satisfies Record<SubmitPullRequestReviewInput["event"], string>
 
+const allowedMergeMethods = (info: {
+	readonly mergeCommitAllowed: boolean
+	readonly squashMergeAllowed: boolean
+	readonly rebaseMergeAllowed: boolean
+}): readonly PullRequestMergeMethod[] => {
+	const methods: PullRequestMergeMethod[] = []
+	if (info.mergeCommitAllowed) methods.push("merge")
+	if (info.squashMergeAllowed) methods.push("squash")
+	if (info.rebaseMergeAllowed) methods.push("rebase")
+	return methods
+}
+
 export class GitHubService extends Context.Service<
 	GitHubService,
 	{
@@ -714,7 +731,7 @@ export class GitHubService extends Context.Service<
 					"--repo",
 					repository,
 					"--json",
-					"number,title,state,isDraft,mergeable,reviewDecision,autoMergeRequest,statusCheckRollup",
+					"number,title,state,isDraft,mergeable,reviewDecision,autoMergeRequest,viewerCanMergeAsAdmin,mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed,statusCheckRollup",
 				])
 				const checkInfo = getCheckInfoFromContexts(info.statusCheckRollup)
 
@@ -729,6 +746,8 @@ export class GitHubService extends Context.Service<
 					checkStatus: checkInfo.checkStatus,
 					checkSummary: checkInfo.checkSummary,
 					autoMergeEnabled: info.autoMergeRequest !== null,
+					viewerCanMergeAsAdmin: info.viewerCanMergeAsAdmin,
+					allowedMethods: allowedMergeMethods(info),
 				} satisfies PullRequestMergeInfo
 			})
 

--- a/src/services/MockGitHubService.ts
+++ b/src/services/MockGitHubService.ts
@@ -178,6 +178,8 @@ export const MockGitHubService = {
 						checkStatus: "passing",
 						checkSummary: "10/10",
 						autoMergeEnabled: false,
+						viewerCanMergeAsAdmin: false,
+						allowedMethods: ["merge", "squash", "rebase"],
 					} satisfies PullRequestMergeInfo),
 				mergePullRequest: () => Effect.void,
 				closePullRequest: () => Effect.void,

--- a/src/ui/modals.tsx
+++ b/src/ui/modals.tsx
@@ -634,7 +634,11 @@ export const MergeModal = ({
 			? shortRepoName(repo)
 			: ""
 	const optionRows = Math.max(1, Math.floor(optionAreaHeight / 2))
-	const visibleOptions = options.slice(0, optionRows)
+	const scrollStart = Math.min(
+		Math.max(0, options.length - optionRows),
+		Math.max(0, selectedIndex - optionRows + 1),
+	)
+	const visibleOptions = options.slice(scrollStart, scrollStart + optionRows)
 	const loadingTopRows = Math.max(0, Math.floor((optionAreaHeight - 1) / 2))
 	const loadingBottomRows = Math.max(0, optionAreaHeight - loadingTopRows - 1)
 
@@ -653,6 +657,7 @@ export const MergeModal = ({
 						{ key: "↑↓", label: "move" },
 						{ key: "enter", label: "confirm" },
 						{ key: "esc", label: "close" },
+						{ key: `${selectedIndex + 1}/${options.length}`, label: "", when: options.length > optionRows, keyFg: colors.muted },
 					]}
 				/>
 			}
@@ -669,7 +674,8 @@ export const MergeModal = ({
 				<PlainLine text={centerCell(mergeUnavailableReason(state.info), rowWidth)} fg={colors.muted} />
 			) : (
 				visibleOptions.map((option, index) => {
-					const isSelected = index === selectedIndex
+					const actualIndex = scrollStart + index
+					const isSelected = actualIndex === selectedIndex
 					const titleColor = option.danger ? colors.error : isSelected ? colors.selectedText : colors.text
 					const titleWidth = Math.max(1, rowWidth - 1)
 					const descriptionWidth = Math.max(1, rowWidth - 1)

--- a/test/mergeActions.test.ts
+++ b/test/mergeActions.test.ts
@@ -13,19 +13,38 @@ const cleanInfo: PullRequestMergeInfo = {
 	checkStatus: "passing",
 	checkSummary: "checks 5/5",
 	autoMergeEnabled: false,
+	viewerCanMergeAsAdmin: false,
+	allowedMethods: ["merge", "squash", "rebase"],
 }
 
 describe("mergeActions ordering", () => {
-	test("source-of-truth order is squash, auto, disable-auto, admin", () => {
-		expect(mergeActions.map((action) => action.action)).toEqual(["squash", "auto", "disable-auto", "admin"])
+	test("source-of-truth order reflects all method-specific actions", () => {
+		expect(mergeActions.map((action) => action.action)).toEqual([
+			"merge",
+			"squash",
+			"rebase",
+			"auto-merge",
+			"auto-squash",
+			"auto-rebase",
+			"disable-auto",
+			"admin-merge",
+			"admin-squash",
+			"admin-rebase",
+		])
 	})
 
 	test("source-of-truth optimistic UI effects match action behavior", () => {
 		expect(Object.fromEntries(mergeActions.map((action) => [action.action, action.optimisticState ?? action.optimisticAutoMergeEnabled ?? null]))).toEqual({
+			merge: null,
 			squash: "merged",
-			auto: true,
+			rebase: null,
+			"auto-merge": true,
+			"auto-squash": true,
+			"auto-rebase": true,
 			"disable-auto": false,
-			admin: "merged",
+			"admin-merge": null,
+			"admin-squash": "merged",
+			"admin-rebase": null,
 		})
 	})
 })
@@ -35,12 +54,53 @@ describe("availableMergeActions", () => {
 		expect(availableMergeActions(null)).toEqual([])
 	})
 
-	test("clean PR offers squash, auto, admin (not disable-auto)", () => {
-		expect(availableMergeActions(cleanInfo).map((a) => a.action)).toEqual(["squash", "auto", "admin"])
+	test("clean PR offers all allowed manual and auto methods", () => {
+		expect(availableMergeActions(cleanInfo).map((a) => a.action)).toEqual([
+			"merge",
+			"squash",
+			"rebase",
+			"auto-merge",
+			"auto-squash",
+			"auto-rebase",
+		])
 	})
 
-	test("auto-merge enabled offers squash, disable-auto, admin (not auto)", () => {
-		expect(availableMergeActions({ ...cleanInfo, autoMergeEnabled: true }).map((a) => a.action)).toEqual(["squash", "disable-auto", "admin"])
+	test("clean PR includes admin actions only when viewer can merge as admin", () => {
+		expect(availableMergeActions({ ...cleanInfo, viewerCanMergeAsAdmin: true }).map((a) => a.action)).toEqual([
+			"merge",
+			"squash",
+			"rebase",
+			"auto-merge",
+			"auto-squash",
+			"auto-rebase",
+			"admin-merge",
+			"admin-squash",
+			"admin-rebase",
+		])
+	})
+
+	test("allowedMethods filters manual, auto, and admin actions", () => {
+		expect(availableMergeActions({
+			...cleanInfo,
+			viewerCanMergeAsAdmin: true,
+			allowedMethods: ["merge", "rebase"],
+		}).map((a) => a.action)).toEqual([
+			"merge",
+			"rebase",
+			"auto-merge",
+			"auto-rebase",
+			"admin-merge",
+			"admin-rebase",
+		])
+	})
+
+	test("auto-merge enabled swaps auto actions for disable-auto", () => {
+		expect(availableMergeActions({ ...cleanInfo, autoMergeEnabled: true }).map((a) => a.action)).toEqual([
+			"merge",
+			"squash",
+			"rebase",
+			"disable-auto",
+		])
 	})
 
 	test("conflicting branch offers nothing", () => {
@@ -51,16 +111,37 @@ describe("availableMergeActions", () => {
 		expect(availableMergeActions({ ...cleanInfo, isDraft: true }).map((a) => a.action)).toEqual([])
 	})
 
-	test("changes-requested hides squash but admin still works", () => {
-		expect(availableMergeActions({ ...cleanInfo, reviewStatus: "changes" }).map((a) => a.action)).toEqual(["auto", "admin"])
+	test("changes-requested hides clean merges but still allows auto and admin when eligible", () => {
+		expect(availableMergeActions({ ...cleanInfo, reviewStatus: "changes", viewerCanMergeAsAdmin: true }).map((a) => a.action)).toEqual([
+			"auto-merge",
+			"auto-squash",
+			"auto-rebase",
+			"admin-merge",
+			"admin-squash",
+			"admin-rebase",
+		])
 	})
 
-	test("pending checks hide squash but admin still works", () => {
-		expect(availableMergeActions({ ...cleanInfo, checkStatus: "pending" }).map((a) => a.action)).toEqual(["auto", "admin"])
+	test("pending checks hides clean merges but still allows auto and admin when eligible", () => {
+		expect(availableMergeActions({ ...cleanInfo, checkStatus: "pending", viewerCanMergeAsAdmin: true }).map((a) => a.action)).toEqual([
+			"auto-merge",
+			"auto-squash",
+			"auto-rebase",
+			"admin-merge",
+			"admin-squash",
+			"admin-rebase",
+		])
 	})
 
-	test("failing checks hide squash but admin still works", () => {
-		expect(availableMergeActions({ ...cleanInfo, checkStatus: "failing" }).map((a) => a.action)).toEqual(["auto", "admin"])
+	test("failing checks hides clean merges but still allows auto and admin when eligible", () => {
+		expect(availableMergeActions({ ...cleanInfo, checkStatus: "failing", viewerCanMergeAsAdmin: true }).map((a) => a.action)).toEqual([
+			"auto-merge",
+			"auto-squash",
+			"auto-rebase",
+			"admin-merge",
+			"admin-squash",
+			"admin-rebase",
+		])
 	})
 
 	test("closed PR offers nothing", () => {


### PR DESCRIPTION
closes #19 

- Shows all available merge methods for a given PR (merge, squash, rebase)
- Shows the admin override options only when the user can actually perform the override

<img width="1139" height="590" alt="image" src="https://github.com/user-attachments/assets/0822cb3e-5347-4105-b911-d2780530b79f" />
