### PR TITLE
feat: add follow-system theme pairs

### DIFF
--- a/.changeset/system-theme-pairs.md
+++ b/.changeset/system-theme-pairs.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/ghui": minor
+---
+
+Add a follow-system theme mode with separate dark and light theme selections while preserving fixed theme selection.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You can also copy `.env.example` to `.env` and edit the values locally.
 - `s`: toggle draft or ready-for-review state
 - `m`: merge
 - `x`: close with confirmation
-- `t`: choose theme, including `System` to match your terminal colors
+- `t`: choose a fixed theme, including `System` to match your terminal colors; press `m` in the theme picker to follow the OS light/dark appearance with separate theme choices
 - `l`: manage labels
 - `o`: open PR in browser
 - `y`: copy PR metadata

--- a/plans/system-theme-pairs.md
+++ b/plans/system-theme-pairs.md
@@ -1,0 +1,34 @@
+# System Theme Pairs
+
+## Why
+
+Users can choose one fixed theme today, including the terminal-derived `System` theme. There is no way to configure separate light and dark themes and have ghui pick between them based on the OS appearance.
+
+## What We'd Ship
+
+- Preserve existing fixed theme selection and the existing `System` terminal-palette theme.
+- Add a follow-system mode that stores one dark theme and one light theme.
+- Let the theme modal switch between fixed and follow-system modes without changing existing keybindings for fixed selection.
+- Resolve the active theme from the detected system appearance when follow-system mode is enabled.
+
+## API / Architecture Mapping
+
+- Extend config with `themeMode`, `darkTheme`, and `lightTheme`, keeping `theme` as the fixed-mode theme.
+- Add pure theme config helpers for normalization and theme resolution.
+- Add OS appearance detection with safe fallbacks.
+- Keep app-level `themeId` as the resolved active theme so downstream UI components remain unchanged.
+
+## Open Questions
+
+- Linux and Windows detection can be expanded after the macOS path is proven.
+- A future version could watch OS appearance changes instead of polling periodically.
+
+## Out Of Scope (For V1)
+
+- Renaming the existing `System` theme.
+- Removing or migrating existing `theme` config.
+- Full desktop-environment-specific Linux detection coverage.
+
+## Status
+
+In progress.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -891,7 +891,7 @@ export const App = () => {
 				previewActiveTheme(resolveThemeId(themeConfigRef.current, appearance))
 			})
 		}
-		const interval = globalThis.setInterval(refreshAppearance, 5000)
+		const interval = globalThis.setInterval(refreshAppearance, 1000)
 		refreshAppearance()
 		return () => {
 			cancelled = true

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2446,11 +2446,13 @@ export const App = () => {
 	}
 
 	const moveThemeSelection = (delta: number) => {
-		const filteredThemes = filterThemeDefinitions(themeModalRef.current.query, themeModalRef.current.tone)
+		const current = themeModalRef.current
+		const filteredThemes = filterThemeDefinitions(current.query, current.tone)
 		if (filteredThemes.length === 0) return
+		const selectedThemeId = current.mode === "fixed" ? current.fixedTheme : current.tone === "dark" ? current.darkTheme : current.lightTheme
 		const currentIndex = Math.max(
 			0,
-			filteredThemes.findIndex((theme) => theme.id === themeIdRef.current),
+			filteredThemes.findIndex((theme) => theme.id === selectedThemeId),
 		)
 		const selectedIndex = wrapIndex(currentIndex + delta, filteredThemes.length)
 		if (selectedIndex === currentIndex) return

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,7 +51,9 @@ import { CacheService, type PullRequestCacheKey } from "./services/CacheService.
 import { Clipboard } from "./services/Clipboard.js"
 import { CommandRunner } from "./services/CommandRunner.js"
 import { GitHubService } from "./services/GitHubService.js"
-import { loadStoredDiffWhitespaceMode, loadStoredThemeId, saveStoredDiffWhitespaceMode, saveStoredThemeId } from "./themeStore.js"
+import { detectSystemAppearance } from "./systemAppearance.js"
+import { fixedThemeConfig, resolveThemeId, systemThemeConfigForTheme, themeConfigWithSelection, type ThemeConfig, type ThemeMode } from "./themeConfig.js"
+import { loadStoredDiffWhitespaceMode, loadStoredThemeConfig, saveStoredDiffWhitespaceMode, saveStoredThemeConfig } from "./themeStore.js"
 import { colors, filterThemeDefinitions, mixHex, pairedThemeId, setActiveTheme, themeDefinitions, themeToneForThemeId, type ThemeId, type ThemeTone } from "./ui/colors.js"
 import {
 	backspace as editorBackspace,
@@ -185,7 +187,12 @@ const githubRuntime = Atom.runtime(
 		Layer.provideMerge(Observability.layer),
 	),
 )
-const [initialThemeId, initialDiffWhitespaceMode] = await Promise.all([Effect.runPromise(loadStoredThemeId), Effect.runPromise(loadStoredDiffWhitespaceMode)])
+const [initialThemeConfig, initialDiffWhitespaceMode, initialSystemAppearance] = await Promise.all([
+	Effect.runPromise(loadStoredThemeConfig),
+	Effect.runPromise(loadStoredDiffWhitespaceMode),
+	detectSystemAppearance(),
+])
+const initialThemeId = resolveThemeId(initialThemeConfig, initialSystemAppearance)
 setActiveTheme(initialThemeId)
 
 interface DetailPlaceholderInput {
@@ -346,6 +353,8 @@ const pullRequestCommentsLoadedAtom = Atom.make<Record<string, "loading" | "read
 const pullRequestDiffCacheAtom = Atom.make<Record<string, PullRequestDiffState>>({}).pipe(Atom.keepAlive)
 
 const activeModalAtom = Atom.make<Modal>(initialModal)
+const themeConfigAtom = Atom.make<ThemeConfig>(initialThemeConfig).pipe(Atom.keepAlive)
+const systemAppearanceAtom = Atom.make<ThemeTone>(initialSystemAppearance).pipe(Atom.keepAlive)
 const themeIdAtom = Atom.make<ThemeId>(initialThemeId).pipe(Atom.keepAlive)
 const labelCacheAtom = Atom.make<Record<string, readonly PullRequestLabel[]>>({}).pipe(Atom.keepAlive)
 const repoMergeMethodsCacheAtom = Atom.make<Record<string, RepositoryMergeMethods>>({}).pipe(Atom.keepAlive)
@@ -711,6 +720,8 @@ export const App = () => {
 	const setPullRequestCommentsLoaded = useAtomSet(pullRequestCommentsLoadedAtom)
 	const setPullRequestDiffCache = useAtomSet(pullRequestDiffCacheAtom)
 	const [activeModal, setActiveModal] = useAtom(activeModalAtom)
+	const [themeConfig, setThemeConfig] = useAtom(themeConfigAtom)
+	const [systemAppearance, setSystemAppearance] = useAtom(systemAppearanceAtom)
 	const [themeId, setThemeId] = useAtom(themeIdAtom)
 	const closeActiveModal = () => setActiveModal(initialModal)
 	const labelModalActive = Modal.$is("Label")(activeModal)
@@ -762,8 +773,12 @@ export const App = () => {
 	const setCommandPalette = makeModalSetter("CommandPalette")
 	const setOpenRepositoryModal = makeModalSetter("OpenRepository")
 	const themeIdRef = useRef(themeId)
+	const themeConfigRef = useRef(themeConfig)
+	const systemAppearanceRef = useRef(systemAppearance)
 	const themeModalRef = useRef(themeModal)
 	themeIdRef.current = themeId
+	themeConfigRef.current = themeConfig
+	systemAppearanceRef.current = systemAppearance
 	themeModalRef.current = themeModal
 	const setLabelCache = useAtomSet(labelCacheAtom)
 	const setRepoMergeMethodsCache = useAtomSet(repoMergeMethodsCacheAtom)
@@ -849,9 +864,40 @@ export const App = () => {
 		}, 2500)
 	}
 
+	const previewActiveTheme = (id: ThemeId) => {
+		setActiveTheme(id)
+		themeIdRef.current = id
+		setThemeId(id)
+	}
+
+	const applyThemeConfig = (config: ThemeConfig, appearance: ThemeTone = systemAppearanceRef.current) => {
+		themeConfigRef.current = config
+		setThemeConfig(config)
+		previewActiveTheme(resolveThemeId(config, appearance))
+	}
+
 	useEffect(() => {
 		renderer.setBackgroundColor(colors.background)
 	}, [renderer, themeId])
+
+	useEffect(() => {
+		if (themeConfig.mode !== "system") return
+		let cancelled = false
+		const refreshAppearance = () => {
+			void detectSystemAppearance().then((appearance) => {
+				if (cancelled || appearance === systemAppearanceRef.current) return
+				systemAppearanceRef.current = appearance
+				setSystemAppearance(appearance)
+				previewActiveTheme(resolveThemeId(themeConfigRef.current, appearance))
+			})
+		}
+		const interval = globalThis.setInterval(refreshAppearance, 5000)
+		refreshAppearance()
+		return () => {
+			cancelled = true
+			globalThis.clearInterval(interval)
+		}
+	}, [themeConfig.mode])
 
 	useEffect(
 		() => () => {
@@ -2350,32 +2396,47 @@ export const App = () => {
 	}
 
 	const openThemeModal = () => {
+		const systemConfig = themeConfig.mode === "system" ? themeConfig : systemThemeConfigForTheme(themeConfig.theme)
 		setThemeModal({
 			query: "",
 			filterMode: false,
-			tone: themeToneForThemeId(themeId),
-			initialThemeId: themeId,
+			mode: themeConfig.mode,
+			tone: themeConfig.mode === "system" ? systemAppearance : themeToneForThemeId(themeId),
+			fixedTheme: themeConfig.mode === "fixed" ? themeConfig.theme : themeId,
+			darkTheme: systemConfig.darkTheme,
+			lightTheme: systemConfig.lightTheme,
+			initialThemeConfig: themeConfig,
 		})
 	}
 
+	const themeConfigFromModal = (state: ThemeModalState): ThemeConfig =>
+		state.mode === "fixed" ? fixedThemeConfig(state.fixedTheme) : { mode: "system", darkTheme: state.darkTheme, lightTheme: state.lightTheme }
+
 	const closeThemeModal = (confirm: boolean) => {
-		const selectedTheme = themeDefinitions.find((theme) => theme.id === themeIdRef.current)
 		if (!confirm) {
-			setActiveTheme(themeModal.initialThemeId)
-			themeIdRef.current = themeModal.initialThemeId
-			setThemeId(themeModal.initialThemeId)
-		} else if (selectedTheme) {
-			void Effect.runPromise(saveStoredThemeId(selectedTheme.id)).catch((error) => flashNotice(errorMessage(error)))
-			flashNotice(`Theme: ${selectedTheme.name}`)
+			applyThemeConfig(themeModal.initialThemeConfig)
+		} else {
+			const nextConfig = themeConfigFromModal(themeModal)
+			applyThemeConfig(nextConfig)
+			void Effect.runPromise(saveStoredThemeConfig(nextConfig)).catch((error) => flashNotice(errorMessage(error)))
+			const selectedTheme = themeDefinitions.find((theme) => theme.id === resolveThemeId(nextConfig, systemAppearanceRef.current))
+			flashNotice(nextConfig.mode === "system" ? "Theme: Follow System" : `Theme: ${selectedTheme?.name ?? themeIdRef.current}`)
 		}
 		closeActiveModal()
 	}
 
 	const previewTheme = (id: ThemeId) => {
-		if (id === themeIdRef.current) return
-		setActiveTheme(id)
-		themeIdRef.current = id
-		setThemeId(id)
+		const current = themeModalRef.current
+		const nextConfig = themeConfigWithSelection(themeConfigFromModal(current), id, current.tone)
+		const next = {
+			...current,
+			fixedTheme: nextConfig.mode === "fixed" ? nextConfig.theme : current.fixedTheme,
+			darkTheme: nextConfig.mode === "system" ? nextConfig.darkTheme : current.darkTheme,
+			lightTheme: nextConfig.mode === "system" ? nextConfig.lightTheme : current.lightTheme,
+		}
+		themeModalRef.current = next
+		setThemeModal(next)
+		previewActiveTheme(id)
 	}
 
 	const toggleDiffWhitespaceMode = () => {
@@ -2422,8 +2483,19 @@ export const App = () => {
 		themeModalRef.current = next
 		setThemeModal(next)
 
-		const nextThemeId = pairedThemeId(themeIdRef.current, tone) ?? filterThemeDefinitions("", tone)[0]?.id
+		const selectedThemeId =
+			current.mode === "system" ? (tone === "dark" ? current.darkTheme : current.lightTheme) : (pairedThemeId(current.fixedTheme, tone) ?? filterThemeDefinitions("", tone)[0]?.id)
+		const nextThemeId = selectedThemeId ?? filterThemeDefinitions("", tone)[0]?.id
 		if (nextThemeId) previewTheme(nextThemeId)
+	}
+
+	const toggleThemeMode = () => {
+		const current = themeModalRef.current
+		const mode: ThemeMode = current.mode === "fixed" ? "system" : "fixed"
+		const next = { ...current, query: "", filterMode: false, mode }
+		themeModalRef.current = next
+		setThemeModal(next)
+		previewActiveTheme(resolveThemeId(themeConfigFromModal(next), systemAppearanceRef.current))
 	}
 
 	const editThemeQuery = (transform: (query: string) => string) => {
@@ -3048,6 +3120,7 @@ export const App = () => {
 			closeWithoutSaving: () => closeThemeModal(false),
 			clearFilter: () => updateThemeQuery("", { filterMode: false }),
 			enterFilterMode: () => updateThemeQuery("", { filterMode: true }),
+			toggleMode: toggleThemeMode,
 			toggleTone: toggleThemeTone,
 			confirmSelection: () => closeThemeModal(true),
 			moveSelection: moveThemeSelection,
@@ -3733,7 +3806,7 @@ export const App = () => {
 				/>
 			) : null}
 			{themeModalActive ? (
-				<ThemeModal state={themeModal} activeThemeId={themeId} modalWidth={themeModalWidth} modalHeight={themeModalHeight} offsetLeft={themeModalLeft} offsetTop={themeModalTop} />
+				<ThemeModal state={themeModal} modalWidth={themeModalWidth} modalHeight={themeModalHeight} offsetLeft={themeModalLeft} offsetTop={themeModalTop} />
 			) : null}
 			{openRepositoryModalActive ? (
 				<OpenRepositoryModal

--- a/src/keymap/themeModal.ts
+++ b/src/keymap/themeModal.ts
@@ -6,6 +6,7 @@ export interface ThemeModalCtx {
 	readonly closeWithoutSaving: () => void
 	readonly clearFilter: () => void
 	readonly enterFilterMode: () => void
+	readonly toggleMode: () => void
 	readonly toggleTone: () => void
 	readonly confirmSelection: () => void
 	readonly moveSelection: (delta: -1 | 1) => void
@@ -24,6 +25,7 @@ export const themeModalKeymap = Theme(
 		},
 	},
 	{ id: "theme-modal.filter", title: "Filter themes", keys: ["/"], run: (s) => s.enterFilterMode() },
+	{ id: "theme-modal.toggle-mode", title: "Toggle fixed/system theme mode", keys: ["m"], when: (s) => !s.filterMode, run: (s) => s.toggleMode() },
 	{ id: "theme-modal.toggle-tone", title: "Toggle light/dark themes", keys: ["tab"], run: (s) => s.toggleTone() },
 	{
 		id: "theme-modal.confirm",

--- a/src/systemAppearance.ts
+++ b/src/systemAppearance.ts
@@ -2,19 +2,44 @@ import type { ThemeTone } from "./ui/colors.js"
 
 export type SystemAppearance = ThemeTone
 
-const detectMacAppearance = async (): Promise<SystemAppearance> => {
-	const proc = Bun.spawn(["defaults", "read", "-g", "AppleInterfaceStyle"], {
+const runCommand = async (command: readonly [string, ...string[]]) => {
+	const [cmd, ...args] = command
+	const proc = Bun.spawn([cmd, ...args], {
 		stdout: "pipe",
 		stderr: "pipe",
 	})
 	const output = await Bun.readableStreamToText(proc.stdout)
-	await proc.exited
+	const exitCode = await proc.exited
+	return exitCode === 0 ? output.trim() : ""
+}
+
+export const appearanceFromLinuxSetting = (value: string): SystemAppearance | null => {
+	const normalized = value.trim().replaceAll("'", "").replaceAll('"', "").toLowerCase()
+	if (normalized.includes("dark")) return "dark"
+	if (normalized.includes("light") || normalized === "default") return "light"
+	return null
+}
+
+const detectMacAppearance = async (): Promise<SystemAppearance> => {
+	const output = await runCommand(["defaults", "read", "-g", "AppleInterfaceStyle"])
 	return output.trim() === "Dark" ? "dark" : "light"
+}
+
+const detectLinuxAppearance = async (): Promise<SystemAppearance> => {
+	for (const command of [
+		["gsettings", "get", "org.gnome.desktop.interface", "color-scheme"],
+		["gsettings", "get", "org.gnome.desktop.interface", "gtk-theme"],
+	] as const) {
+		const appearance = appearanceFromLinuxSetting(await runCommand(command))
+		if (appearance) return appearance
+	}
+	return "dark"
 }
 
 export const detectSystemAppearance = async (): Promise<SystemAppearance> => {
 	try {
 		if (process.platform === "darwin") return await detectMacAppearance()
+		if (process.platform === "linux") return await detectLinuxAppearance()
 	} catch {
 		return "light"
 	}

--- a/src/systemAppearance.ts
+++ b/src/systemAppearance.ts
@@ -1,0 +1,23 @@
+import type { ThemeTone } from "./ui/colors.js"
+
+export type SystemAppearance = ThemeTone
+
+const detectMacAppearance = async (): Promise<SystemAppearance> => {
+	const proc = Bun.spawn(["defaults", "read", "-g", "AppleInterfaceStyle"], {
+		stdout: "pipe",
+		stderr: "pipe",
+	})
+	const output = await Bun.readableStreamToText(proc.stdout)
+	await proc.exited
+	return output.trim() === "Dark" ? "dark" : "light"
+}
+
+export const detectSystemAppearance = async (): Promise<SystemAppearance> => {
+	try {
+		if (process.platform === "darwin") return await detectMacAppearance()
+	} catch {
+		return "light"
+	}
+
+	return "dark"
+}

--- a/src/themeConfig.ts
+++ b/src/themeConfig.ts
@@ -1,0 +1,62 @@
+import { filterThemeDefinitions, isThemeId, pairedThemeId, themeToneForThemeId, type ThemeId, type ThemeTone } from "./ui/colors.js"
+
+export type ThemeMode = "fixed" | "system"
+
+export type ThemeConfig = { readonly mode: "fixed"; readonly theme: ThemeId } | { readonly mode: "system"; readonly darkTheme: ThemeId; readonly lightTheme: ThemeId }
+
+export interface StoredThemeConfigInput {
+	readonly theme?: unknown
+	readonly themeMode?: unknown
+	readonly darkTheme?: unknown
+	readonly lightTheme?: unknown
+}
+
+const defaultDarkThemeId = "ghui" satisfies ThemeId
+const defaultLightThemeId = "catppuccin-latte" satisfies ThemeId
+
+export const defaultThemeConfig: ThemeConfig = { mode: "fixed", theme: defaultDarkThemeId }
+
+const firstThemeForTone = (tone: ThemeTone) => filterThemeDefinitions("", tone)[0]?.id
+
+export const fallbackThemeForTone = (sourceTheme: ThemeId, tone: ThemeTone): ThemeId => {
+	if (themeToneForThemeId(sourceTheme) === tone) return sourceTheme
+	return pairedThemeId(sourceTheme, tone) ?? firstThemeForTone(tone) ?? (tone === "dark" ? defaultDarkThemeId : defaultLightThemeId)
+}
+
+const storedThemeId = (value: unknown, fallback: ThemeId) => (isThemeId(value) ? value : fallback)
+
+const storedThemeIdForTone = (value: unknown, tone: ThemeTone, fallback: ThemeId) => {
+	const id = storedThemeId(value, fallback)
+	return themeToneForThemeId(id) === tone ? id : fallback
+}
+
+export const normalizeThemeConfig = (config: StoredThemeConfigInput): ThemeConfig => {
+	const fixedTheme = storedThemeId(config.theme, defaultDarkThemeId)
+	if (config.themeMode !== "system") return { mode: "fixed", theme: fixedTheme }
+
+	const darkFallback = fallbackThemeForTone(fixedTheme, "dark")
+	const lightFallback = fallbackThemeForTone(fixedTheme, "light")
+	return {
+		mode: "system",
+		darkTheme: storedThemeIdForTone(config.darkTheme, "dark", darkFallback),
+		lightTheme: storedThemeIdForTone(config.lightTheme, "light", lightFallback),
+	}
+}
+
+export const resolveThemeId = (config: ThemeConfig, appearance: ThemeTone): ThemeId =>
+	config.mode === "fixed" ? config.theme : appearance === "dark" ? config.darkTheme : config.lightTheme
+
+export const themeConfigWithSelection = (config: ThemeConfig, theme: ThemeId, tone: ThemeTone): ThemeConfig => {
+	if (config.mode === "fixed") return { mode: "fixed", theme }
+	return tone === "dark" ? { ...config, darkTheme: theme } : { ...config, lightTheme: theme }
+}
+
+export const fixedThemeConfig = (theme: ThemeId): ThemeConfig => ({ mode: "fixed", theme })
+
+export const systemThemeConfig = (darkTheme: ThemeId, lightTheme: ThemeId): ThemeConfig => ({ mode: "system", darkTheme, lightTheme })
+
+export const systemThemeConfigForTheme = (theme: ThemeId): Extract<ThemeConfig, { readonly mode: "system" }> => ({
+	mode: "system",
+	darkTheme: fallbackThemeForTone(theme, "dark"),
+	lightTheme: fallbackThemeForTone(theme, "light"),
+})

--- a/src/themeStore.ts
+++ b/src/themeStore.ts
@@ -3,10 +3,14 @@ import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 import { Effect, Schema } from "effect"
 import { isThemeId, type ThemeId } from "./ui/colors.js"
+import { normalizeThemeConfig, type ThemeConfig } from "./themeConfig.js"
 import { DiffWhitespaceMode } from "./ui/diff.js"
 
 interface StoredConfig {
 	readonly theme?: unknown
+	readonly themeMode?: unknown
+	readonly darkTheme?: unknown
+	readonly lightTheme?: unknown
 	readonly diffWhitespaceMode?: unknown
 }
 
@@ -43,6 +47,11 @@ export const loadStoredThemeId: Effect.Effect<ThemeId> = Effect.catchCause(
 	() => Effect.succeed("ghui" satisfies ThemeId),
 )
 
+export const loadStoredThemeConfig: Effect.Effect<ThemeConfig> = Effect.catchCause(
+	Effect.tryPromise(async () => normalizeThemeConfig(await readStoredConfig())),
+	() => Effect.succeed(normalizeThemeConfig({})),
+)
+
 export const loadStoredDiffWhitespaceMode: Effect.Effect<DiffWhitespaceMode> = Effect.catchCause(
 	Effect.tryPromise(async () => {
 		const config = await readStoredConfig()
@@ -54,9 +63,25 @@ export const loadStoredDiffWhitespaceMode: Effect.Effect<DiffWhitespaceMode> = E
 export const saveStoredThemeId = (theme: ThemeId): Effect.Effect<void> =>
 	Effect.tryPromise(async () => {
 		const config = await readStoredConfig()
-		if (config.theme === theme) return
+		if (config.themeMode !== "system" && config.theme === theme) return
 
-		await writeStoredConfig({ ...config, theme })
+		await writeStoredConfig({ ...config, themeMode: "fixed", theme })
+	})
+
+export const saveStoredThemeConfig = (themeConfig: ThemeConfig): Effect.Effect<void> =>
+	Effect.tryPromise(async () => {
+		const config = await readStoredConfig()
+		const nextConfig =
+			themeConfig.mode === "fixed"
+				? { ...config, themeMode: "fixed", theme: themeConfig.theme }
+				: {
+						...config,
+						themeMode: "system",
+						darkTheme: themeConfig.darkTheme,
+						lightTheme: themeConfig.lightTheme,
+					}
+
+		await writeStoredConfig(nextConfig)
 	})
 
 export const saveStoredDiffWhitespaceMode = (diffWhitespaceMode: DiffWhitespaceMode): Effect.Effect<void> =>

--- a/src/ui/modals.tsx
+++ b/src/ui/modals.tsx
@@ -13,6 +13,7 @@ import { allowedMergeMethodList } from "../domain.js"
 import { getMergeKindDefinition, mergeKindRowTitle, visibleMergeKinds } from "../mergeActions.js"
 import { clampCursor, commentEditorLines, cursorLineIndexForLines } from "./commentEditor.js"
 import { colors, filterThemeDefinitions, oppositeThemeTone, themeDefinitions, type ThemeId, type ThemeTone } from "./colors.js"
+import type { ThemeConfig, ThemeMode } from "../themeConfig.js"
 import { commentDisplayRows, CommentSegmentsLine, type CommentDisplayLine } from "./comments.js"
 import { diffFileStats, diffFileStatsText, type DiffFilePatch } from "./diff.js"
 import {
@@ -121,8 +122,12 @@ export interface SubmitReviewModalState {
 export interface ThemeModalState {
 	readonly query: string
 	readonly filterMode: boolean
+	readonly mode: ThemeMode
 	readonly tone: ThemeTone
-	readonly initialThemeId: ThemeId
+	readonly fixedTheme: ThemeId
+	readonly darkTheme: ThemeId
+	readonly lightTheme: ThemeId
+	readonly initialThemeConfig: ThemeConfig
 }
 
 export interface CommandPaletteState {
@@ -401,8 +406,12 @@ export const initialSubmitReviewModalState: SubmitReviewModalState = {
 export const initialThemeModalState: ThemeModalState = {
 	query: "",
 	filterMode: false,
+	mode: "fixed",
 	tone: "dark",
-	initialThemeId: "ghui",
+	fixedTheme: "ghui",
+	darkTheme: "ghui",
+	lightTheme: "catppuccin-latte",
+	initialThemeConfig: { mode: "fixed", theme: "ghui" },
 }
 
 export const initialCommandPaletteState: CommandPaletteState = {
@@ -1271,14 +1280,12 @@ export const CommentThreadModal = ({
 
 export const ThemeModal = ({
 	state,
-	activeThemeId,
 	modalWidth,
 	modalHeight,
 	offsetLeft,
 	offsetTop,
 }: {
 	state: ThemeModalState
-	activeThemeId: ThemeId
 	modalWidth: number
 	modalHeight: number
 	offsetLeft: number
@@ -1286,9 +1293,10 @@ export const ThemeModal = ({
 }) => {
 	const { contentWidth, bodyHeight: maxVisible, rowWidth } = standardModalDims(modalWidth, modalHeight)
 	const filteredThemes = filterThemeDefinitions(state.query, state.tone)
-	const activeIndex = filteredThemes.findIndex((theme) => theme.id === activeThemeId)
+	const selectedThemeId = state.mode === "fixed" ? state.fixedTheme : state.tone === "dark" ? state.darkTheme : state.lightTheme
+	const activeIndex = filteredThemes.findIndex((theme) => theme.id === selectedThemeId)
 	const selectedIndex = Math.max(0, activeIndex)
-	const selectedTheme = filteredThemes[selectedIndex] ?? themeDefinitions.find((theme) => theme.id === activeThemeId) ?? themeDefinitions[0]!
+	const selectedTheme = filteredThemes[selectedIndex] ?? themeDefinitions.find((theme) => theme.id === selectedThemeId) ?? themeDefinitions[0]!
 	const scrollStart = Math.min(Math.max(0, filteredThemes.length - maxVisible), Math.max(0, selectedIndex - maxVisible + 1))
 	const visibleThemes = filteredThemes.slice(scrollStart, scrollStart + maxVisible)
 	const countText = `${filteredThemes.length === 0 ? 0 : selectedIndex + 1}/${filteredThemes.length}`
@@ -1299,6 +1307,13 @@ export const ThemeModal = ({
 	const messageBottomRows = Math.max(0, maxVisible - messageTopRows - 1)
 	const toneLabel = state.tone === "dark" ? "Dark" : "Light"
 	const nextToneLabel = oppositeThemeTone(state.tone)
+	const selectedDarkTheme = themeDefinitions.find((theme) => theme.id === state.darkTheme)
+	const selectedLightTheme = themeDefinitions.find((theme) => theme.id === state.lightTheme)
+	const fixedTheme = themeDefinitions.find((theme) => theme.id === state.fixedTheme)
+	const modeSummary =
+		state.mode === "fixed"
+			? `Fixed: ${fixedTheme?.name ?? state.fixedTheme}`
+			: `Follow System: Dark ${selectedDarkTheme?.name ?? state.darkTheme}, Light ${selectedLightTheme?.name ?? state.lightTheme}`
 
 	return (
 		<StandardModal
@@ -1306,7 +1321,7 @@ export const ThemeModal = ({
 			top={offsetTop}
 			width={modalWidth}
 			height={modalHeight}
-			title={`${toneLabel} Themes`}
+			title={state.mode === "fixed" ? `${toneLabel} Themes` : `${toneLabel} System Theme`}
 			headerRight={{ text: countText }}
 			subtitle={
 				state.filterMode ? (
@@ -1315,14 +1330,15 @@ export const ThemeModal = ({
 						<span fg={state.query.length > 0 ? colors.text : colors.muted}>{fitCell(subtitleText, subtitleWidth)}</span>
 					</TextLine>
 				) : (
-					<PlainLine text={fitCell(subtitleText, subtitleWidth)} fg={colors.muted} />
+					<PlainLine text={fitCell(state.mode === "fixed" ? `${modeSummary} - ${subtitleText}` : modeSummary, subtitleWidth)} fg={colors.muted} />
 				)
 			}
 			footer={
 				<HintRow
 					items={[
+						{ key: "m", label: state.mode === "fixed" ? "follow system" : "fixed" },
 						{ key: "tab", label: `${nextToneLabel} mode` },
-						{ key: "enter", label: "select" },
+						{ key: "enter", label: "save" },
 						{ key: "esc", label: "cancel" },
 					]}
 				/>
@@ -1338,7 +1354,7 @@ export const ThemeModal = ({
 				visibleThemes.map((theme, index) => {
 					const actualIndex = scrollStart + index
 					const isSelected = actualIndex === selectedIndex
-					const isActive = theme.id === activeThemeId
+					const isActive = theme.id === selectedThemeId
 					const marker = isActive ? "✓" : " "
 					const swatchWidth = 6
 					const nameWidth = Math.max(1, rowWidth - swatchWidth - 3)

--- a/test/systemAppearance.test.ts
+++ b/test/systemAppearance.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test"
+import { appearanceFromLinuxSetting } from "../src/systemAppearance.js"
+
+describe("appearanceFromLinuxSetting", () => {
+	test("detects GNOME dark preference", () => {
+		expect(appearanceFromLinuxSetting("'prefer-dark'")).toBe("dark")
+	})
+
+	test("detects GNOME light/default preference", () => {
+		expect(appearanceFromLinuxSetting("'prefer-light'")).toBe("light")
+		expect(appearanceFromLinuxSetting("'default'")).toBe("light")
+	})
+
+	test("detects dark GTK themes", () => {
+		expect(appearanceFromLinuxSetting("'Adwaita-dark'")).toBe("dark")
+	})
+
+	test("ignores unknown settings", () => {
+		expect(appearanceFromLinuxSetting("")).toBeNull()
+		expect(appearanceFromLinuxSetting("'Adwaita'")).toBeNull()
+	})
+})

--- a/test/themeConfig.test.ts
+++ b/test/themeConfig.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test"
+import { normalizeThemeConfig, resolveThemeId, systemThemeConfigForTheme, themeConfigWithSelection } from "../src/themeConfig.js"
+
+describe("normalizeThemeConfig", () => {
+	test("keeps existing fixed theme config as the default", () => {
+		expect(normalizeThemeConfig({ theme: "catppuccin" })).toEqual({ mode: "fixed", theme: "catppuccin" })
+	})
+
+	test("builds follow-system config with dark and light themes", () => {
+		expect(normalizeThemeConfig({ themeMode: "system", darkTheme: "catppuccin", lightTheme: "catppuccin-latte" })).toEqual({
+			mode: "system",
+			darkTheme: "catppuccin",
+			lightTheme: "catppuccin-latte",
+		})
+	})
+
+	test("falls back to paired themes for invalid system entries", () => {
+		expect(normalizeThemeConfig({ themeMode: "system", theme: "solarized-dark", darkTheme: "solarized-light", lightTheme: "missing" })).toEqual({
+			mode: "system",
+			darkTheme: "solarized-dark",
+			lightTheme: "solarized-light",
+		})
+	})
+})
+
+describe("resolveThemeId", () => {
+	test("resolves fixed theme irrespective of appearance", () => {
+		const config = { mode: "fixed", theme: "rose-pine" } as const
+		expect(resolveThemeId(config, "dark")).toBe("rose-pine")
+		expect(resolveThemeId(config, "light")).toBe("rose-pine")
+	})
+
+	test("resolves system theme by appearance", () => {
+		const config = { mode: "system", darkTheme: "rose-pine", lightTheme: "rose-pine-dawn" } as const
+		expect(resolveThemeId(config, "dark")).toBe("rose-pine")
+		expect(resolveThemeId(config, "light")).toBe("rose-pine-dawn")
+	})
+})
+
+describe("themeConfigWithSelection", () => {
+	test("updates the selected system tone only", () => {
+		expect(themeConfigWithSelection({ mode: "system", darkTheme: "ghui", lightTheme: "catppuccin-latte" }, "rose-pine-dawn", "light")).toEqual({
+			mode: "system",
+			darkTheme: "ghui",
+			lightTheme: "rose-pine-dawn",
+		})
+	})
+
+	test("creates a paired system config from one fixed theme", () => {
+		expect(systemThemeConfigForTheme("gruvbox")).toEqual({ mode: "system", darkTheme: "gruvbox", lightTheme: "gruvbox-light" })
+	})
+})


### PR DESCRIPTION
## Summary
- Add a follow-system theme mode that resolves separate dark and light theme selections from the OS appearance.
- Preserve existing fixed theme selection, including the current terminal-palette `System` theme.
- Extend the theme picker UI with an `m` toggle for fixed/follow-system mode while keeping `tab` for dark/light lists.

## Testing
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run test`

## Reference Image

<img width="537" height="331" alt="image" src="https://github.com/user-attachments/assets/59b378f0-063d-49fd-99a4-c6d882d82bcd" />