### PR TITLE
(Omarchy) theme reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,23 @@ GHUI_PR_FETCH_LIMIT=100 ghui
 
 You can also copy `.env.example` to `.env` and edit the values locally.
 
+ghui stores UI preferences in `config.json` under `GHUI_CONFIG_DIR` when set,
+otherwise under the platform config directory. On Linux this is normally
+`~/.config/ghui/config.json`.
+
+Example:
+
+```json
+{
+	"theme": "system",
+	"systemThemeAutoReload": true
+}
+```
+
+`systemThemeAutoReload` defaults to `false`. Set it to `true` to let external
+theme reload signals update the active system theme palette while ghui is
+running.
+
 ## Keybindings
 
 - `up` / `down`: move selection

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -230,6 +230,10 @@ interface DetailHydration {
 	notifyError: boolean
 }
 
+interface AppProps {
+	readonly systemThemeGeneration?: number
+}
+
 const PR_FETCH_RETRIES = 6
 const FOCUS_RETURN_REFRESH_MIN_MS = 60_000
 const FOCUSED_IDLE_REFRESH_MS = 5 * 60_000
@@ -678,7 +682,7 @@ const getDetailPlaceholderContent = ({ status, retryProgress, loadingIndicator, 
 	}
 }
 
-export const App = () => {
+export const App = ({ systemThemeGeneration = 0 }: AppProps) => {
 	const renderer = useRenderer()
 	const { width, height } = useTerminalDimensions()
 	const registry = useContext(RegistryContext)
@@ -851,7 +855,7 @@ export const App = () => {
 
 	useEffect(() => {
 		renderer.setBackgroundColor(colors.background)
-	}, [renderer, themeId])
+	}, [renderer, themeId, systemThemeGeneration])
 
 	useEffect(
 		() => () => {
@@ -3411,6 +3415,7 @@ export const App = () => {
 					paneWidth={contentWidth}
 					height={wideBodyHeight}
 					loadingIndicator={loadingIndicator}
+					themeGeneration={systemThemeGeneration}
 				/>
 			) : diffFullView ? (
 				<PullRequestDiffPane
@@ -3431,6 +3436,7 @@ export const App = () => {
 					selectedCommentThread={selectedDiffCommentThread}
 					onSelectCommentLine={selectDiffCommentLine}
 					themeId={themeId}
+					themeGeneration={systemThemeGeneration}
 				/>
 			) : detailFullView && isSelectedPullRequestDetailLoading && selectedPullRequest ? (
 				<box flexGrow={1} flexDirection="column">
@@ -3466,6 +3472,7 @@ export const App = () => {
 									bodyLineLimit={DETAIL_BODY_SCROLL_LIMIT}
 									loadingIndicator={loadingIndicator}
 									themeId={themeId}
+									themeGeneration={systemThemeGeneration}
 									onLinkOpen={openLinkInBrowser}
 								/>
 							</scrollbox>
@@ -3479,6 +3486,7 @@ export const App = () => {
 							placeholderContent={detailPlaceholderContent}
 							loadingIndicator={loadingIndicator}
 							themeId={themeId}
+							themeGeneration={systemThemeGeneration}
 							onLinkOpen={openLinkInBrowser}
 						/>
 					)}
@@ -3530,6 +3538,7 @@ export const App = () => {
 										bodyLineLimit={DETAIL_BODY_SCROLL_LIMIT}
 										loadingIndicator={loadingIndicator}
 										themeId={themeId}
+										themeGeneration={systemThemeGeneration}
 										onLinkOpen={openLinkInBrowser}
 									/>
 								</scrollbox>
@@ -3559,6 +3568,7 @@ export const App = () => {
 									bodyLineLimit={DETAIL_BODY_SCROLL_LIMIT}
 									loadingIndicator={loadingIndicator}
 									themeId={themeId}
+									themeGeneration={systemThemeGeneration}
 									onLinkOpen={openLinkInBrowser}
 								/>
 							</scrollbox>
@@ -3572,6 +3582,7 @@ export const App = () => {
 							placeholderContent={detailPlaceholderContent}
 							loadingIndicator={loadingIndicator}
 							themeId={themeId}
+							themeGeneration={systemThemeGeneration}
 							onLinkOpen={openLinkInBrowser}
 						/>
 					)}
@@ -3588,6 +3599,7 @@ export const App = () => {
 						placeholderContent={detailPlaceholderContent}
 						loadingIndicator={loadingIndicator}
 						themeId={themeId}
+						themeGeneration={systemThemeGeneration}
 						onLinkOpen={openLinkInBrowser}
 					/>
 					<Divider width={contentWidth} />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,9 @@
 
 import { addDefaultParsers, createCliRenderer } from "@opentui/core"
 import { createRoot, useRenderer, useTerminalDimensions } from "@opentui/react"
+import { Effect } from "effect"
 import { useEffect, useState } from "react"
+import { loadStoredSystemThemeAutoReload } from "./themeStore.js"
 import { colors, setSystemThemeColors } from "./ui/colors.js"
 import { LoadingLogoPane } from "./ui/LoadingLogo.js"
 import { SPINNER_INTERVAL_MS } from "./ui/spinner.js"
@@ -60,6 +62,23 @@ const renderer = await createCliRenderer({
 	},
 })
 
+const reloadSystemThemeColors = async () => {
+	renderer.clearPaletteCache()
+	const terminalColors = await renderer.getPalette({ timeout: 150, size: 16 })
+	setSystemThemeColors(terminalColors)
+	renderer.setBackgroundColor(colors.background)
+}
+
+const reloadSystemThemeColorsFromSignal = async () => {
+	const systemThemeAutoReload = await Effect.runPromise(loadStoredSystemThemeAutoReload)
+	if (!systemThemeAutoReload) return
+	await reloadSystemThemeColors()
+}
+
+process.on("SIGUSR2", () => {
+	void reloadSystemThemeColorsFromSignal().catch(() => {})
+})
+
 const Bootstrap = () => {
 	const [appBundle, setAppBundle] = useState<AppBundle | null>(null)
 
@@ -69,13 +88,7 @@ const Bootstrap = () => {
 			addGhUiParsers()
 
 			const appBundlePromise = Promise.all([import("@effect/atom-react"), import("./App.js")])
-			const palettePromise = renderer
-				.getPalette({ timeout: 150, size: 16 })
-				.then((terminalColors) => {
-					if (cancelled) return
-					setSystemThemeColors(terminalColors)
-				})
-				.catch(() => {})
+			const palettePromise = reloadSystemThemeColors().catch(() => {})
 
 			void Promise.all([appBundlePromise, palettePromise]).then(([[{ RegistryProvider }, { App }]]) => {
 				if (cancelled) return

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,6 +31,8 @@ type AppBundle = {
 	readonly App: (typeof import("./App.js"))["App"]
 }
 
+let notifySystemThemeReload = () => {}
+
 const StartupLogo = () => {
 	const startupRenderer = useRenderer()
 	const { width, height } = useTerminalDimensions()
@@ -67,6 +69,7 @@ const reloadSystemThemeColors = async () => {
 	const terminalColors = await renderer.getPalette({ timeout: 150, size: 16 })
 	setSystemThemeColors(terminalColors)
 	renderer.setBackgroundColor(colors.background)
+	notifySystemThemeReload()
 }
 
 const reloadSystemThemeColorsFromSignal = async () => {
@@ -81,9 +84,11 @@ process.on("SIGUSR2", () => {
 
 const Bootstrap = () => {
 	const [appBundle, setAppBundle] = useState<AppBundle | null>(null)
+	const [systemThemeGeneration, setSystemThemeGeneration] = useState(0)
 
 	useEffect(() => {
 		let cancelled = false
+		notifySystemThemeReload = () => setSystemThemeGeneration((current) => current + 1)
 		const timer = globalThis.setTimeout(() => {
 			addGhUiParsers()
 
@@ -98,6 +103,7 @@ const Bootstrap = () => {
 
 		return () => {
 			cancelled = true
+			notifySystemThemeReload = () => {}
 			globalThis.clearTimeout(timer)
 		}
 	}, [])
@@ -106,7 +112,7 @@ const Bootstrap = () => {
 		const { RegistryProvider, App } = appBundle
 		return (
 			<RegistryProvider>
-				<App />
+				<App systemThemeGeneration={systemThemeGeneration} />
 			</RegistryProvider>
 		)
 	}

--- a/src/themeStore.ts
+++ b/src/themeStore.ts
@@ -8,6 +8,7 @@ import { DiffWhitespaceMode } from "./ui/diff.js"
 interface StoredConfig {
 	readonly theme?: unknown
 	readonly diffWhitespaceMode?: unknown
+	readonly systemThemeAutoReload?: unknown
 }
 
 const configDirectory = () => {
@@ -49,6 +50,14 @@ export const loadStoredDiffWhitespaceMode: Effect.Effect<DiffWhitespaceMode> = E
 		return Schema.is(DiffWhitespaceMode)(config.diffWhitespaceMode) ? config.diffWhitespaceMode : "ignore"
 	}),
 	() => Effect.succeed("ignore" satisfies DiffWhitespaceMode),
+)
+
+export const loadStoredSystemThemeAutoReload: Effect.Effect<boolean> = Effect.catchCause(
+	Effect.tryPromise(async () => {
+		const config = await readStoredConfig()
+		return typeof config.systemThemeAutoReload === "boolean" ? config.systemThemeAutoReload : false
+	}),
+	() => Effect.succeed(false),
 )
 
 export const saveStoredThemeId = (theme: ThemeId): Effect.Effect<void> =>

--- a/src/ui/CommentsPane.tsx
+++ b/src/ui/CommentsPane.tsx
@@ -179,6 +179,7 @@ export const CommentsPane = ({
 	paneWidth,
 	height,
 	loadingIndicator,
+	themeGeneration,
 }: {
 	pullRequest: PullRequestItem
 	comments: readonly PullRequestComment[]
@@ -189,8 +190,9 @@ export const CommentsPane = ({
 	paneWidth: number
 	height: number
 	loadingIndicator: string
+	themeGeneration: number
 }) => {
-	const realBlocks = useMemo(() => buildBlocks(orderedComments, contentWidth), [orderedComments, contentWidth])
+	const realBlocks = useMemo(() => buildBlocks(orderedComments, contentWidth), [orderedComments, contentWidth, themeGeneration])
 	const blocks = useMemo<readonly CommentBlock[]>(() => [...realBlocks, placeholderBlock], [realBlocks])
 	const offsets = useMemo(() => blockOffsets(blocks), [blocks])
 	const scrollboxRef = useRef<ScrollBoxRenderable | null>(null)

--- a/src/ui/DetailsPane.tsx
+++ b/src/ui/DetailsPane.tsx
@@ -619,6 +619,7 @@ export const DetailBody = ({
 	bodyLineLimit = bodyLines,
 	loadingIndicator,
 	themeId,
+	themeGeneration,
 	onLinkOpen,
 }: {
 	pullRequest: PullRequestItem
@@ -627,12 +628,13 @@ export const DetailBody = ({
 	bodyLineLimit?: number
 	loadingIndicator: string
 	themeId: ThemeId
+	themeGeneration: number
 	onLinkOpen?: (url: string) => void
 }) => {
 	const renderer = useRenderer()
 	const [hoveredUrl, setHoveredUrl] = useState<string | null>(null)
 
-	const previewLines = useMemo(() => bodyPreview(pullRequest.body, contentWidth, bodyLineLimit), [pullRequest, contentWidth, bodyLineLimit, themeId])
+	const previewLines = useMemo(() => bodyPreview(pullRequest.body, contentWidth, bodyLineLimit), [pullRequest, contentWidth, bodyLineLimit, themeId, themeGeneration])
 
 	const urlPositions = useMemo(() => collectUrlPositions(previewLines), [previewLines])
 
@@ -749,6 +751,7 @@ export const DetailsPane = ({
 	placeholderContent,
 	loadingIndicator,
 	themeId,
+	themeGeneration,
 	onLinkOpen,
 }: {
 	pullRequest: PullRequestItem | null
@@ -763,6 +766,7 @@ export const DetailsPane = ({
 	placeholderContent: DetailPlaceholderContent
 	loadingIndicator: string
 	themeId: ThemeId
+	themeGeneration: number
 	onLinkOpen?: (url: string) => void
 }) => {
 	const contentHeight = getDetailsPaneHeight({ pullRequest, contentWidth, bodyLines: bodyLineLimit, paneWidth, showChecks, comments, commentsStatus })
@@ -787,6 +791,7 @@ export const DetailsPane = ({
 						bodyLineLimit={bodyLineLimit}
 						loadingIndicator={loadingIndicator}
 						themeId={themeId}
+						themeGeneration={themeGeneration}
 						{...(onLinkOpen ? { onLinkOpen } : {})}
 					/>
 				</>

--- a/src/ui/PullRequestDiffPane.tsx
+++ b/src/ui/PullRequestDiffPane.tsx
@@ -99,6 +99,7 @@ export const PullRequestDiffPane = ({
 	selectedCommentThread,
 	onSelectCommentLine,
 	themeId,
+	themeGeneration,
 }: {
 	pullRequest: PullRequestItem | null
 	diffState: PullRequestDiffState | undefined
@@ -117,9 +118,10 @@ export const PullRequestDiffPane = ({
 	selectedCommentThread: readonly PullRequestReviewComment[]
 	onSelectCommentLine: (renderLine: number, side: DiffCommentSide | null) => void
 	themeId: ThemeId
+	themeGeneration: number
 }) => {
 	const readyFiles = diffState?._tag === "Ready" ? diffState.files : []
-	const syntaxStyle = useMemo(() => createDiffSyntaxStyle(), [themeId])
+	const syntaxStyle = useMemo(() => createDiffSyntaxStyle(), [themeId, themeGeneration])
 
 	if (!pullRequest) {
 		return <LoadingPane content={{ title: "No pull request selected", hint: "Press esc to go back" }} width={paneWidth} height={height} />

--- a/test/themeStore.test.ts
+++ b/test/themeStore.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { Effect } from "effect"
+import { loadStoredSystemThemeAutoReload } from "../src/themeStore.js"
+
+const originalConfigDir = process.env.GHUI_CONFIG_DIR
+const tempDirs: string[] = []
+
+const restoreConfigDir = () => {
+	if (originalConfigDir === undefined) {
+		delete process.env.GHUI_CONFIG_DIR
+	} else {
+		process.env.GHUI_CONFIG_DIR = originalConfigDir
+	}
+}
+
+afterEach(async () => {
+	restoreConfigDir()
+	await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })))
+	tempDirs.length = 0
+})
+
+const useTempConfig = async (content?: string) => {
+	const dir = await mkdtemp(join(tmpdir(), "ghui-theme-store-"))
+	tempDirs.push(dir)
+	process.env.GHUI_CONFIG_DIR = dir
+	if (content !== undefined) await writeFile(join(dir, "config.json"), content)
+}
+
+const loadSystemThemeAutoReload = () => Effect.runPromise(loadStoredSystemThemeAutoReload)
+
+describe("loadStoredSystemThemeAutoReload", () => {
+	test("defaults to disabled", async () => {
+		await useTempConfig()
+
+		expect(await loadSystemThemeAutoReload()).toBe(false)
+	})
+
+	test("reads an enabled setting", async () => {
+		await useTempConfig('{"systemThemeAutoReload":true}')
+
+		expect(await loadSystemThemeAutoReload()).toBe(true)
+	})
+
+	test("reads a disabled setting", async () => {
+		await useTempConfig('{"systemThemeAutoReload":false}')
+
+		expect(await loadSystemThemeAutoReload()).toBe(false)
+	})
+
+	test("ignores non-boolean values", async () => {
+		await useTempConfig('{"systemThemeAutoReload":"true"}')
+
+		expect(await loadSystemThemeAutoReload()).toBe(false)
+	})
+})


### PR DESCRIPTION
hi 

would be nice to have a hot autoreload of the system theme while working with ghui

so when the user fires up the main menu in omarchy:
-> style
-> theme
-> sets some new theme

the theming gets-reaplied to the current ghui instance without the need to restart that

I tested it on my oma system with

```bash
~/.config/omarchy/hooks/theme-set:

  #!/bin/bash
  set -euo pipefail

  if pgrep -x ghui >/dev/null; then
    pkill -SIGUSR2 -x ghui
  fi

  if pgrep -f "$HOME/Dropbox/projects/anomaly/ghui/src/[s]tandalone.ts" >/dev/null; then
    pkill -SIGUSR2 -f "$HOME/Dropbox/projects/anomaly/ghui/src/[s]tandalone.ts"
  fi
```

can send a video or so, it seems to work