### PR TITLE
feat: Release tag management

### DIFF
--- a/.changeset/release-create-edit-form.md
+++ b/.changeset/release-create-edit-form.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/ghui": minor
+---
+
+Add a release form for cutting and editing GitHub releases. Open via "New release…" in the command palette or `n` (new) / `e` (edit) on the releases overlay. Fields cover tag, target branch, title, multi-line description (with multiline body editor), pre-release toggle, and the `make_latest` tri-state. `ctrl-g` generates release notes (only fills empty title/body, mirroring github.com), `ctrl-s` saves a draft, and `ctrl-↵` publishes; the same form covers updating an existing release. Default branch is fetched lazily for the target placeholder.

--- a/.changeset/release-delete-and-docs.md
+++ b/.changeset/release-delete-and-docs.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/ghui": minor
+---
+
+Add a delete-with-confirmation flow for releases (`shift-d` from the releases overlay or details panel) and document the new Releases mode in the README. The confirm modal calls out that deleting a published release leaves the underlying git tag in place, matching GitHub's behaviour.

--- a/.changeset/release-form-prefill-previous-tag.md
+++ b/.changeset/release-form-prefill-previous-tag.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/ghui": patch
+---
+
+Prefill the tag field of the new-release form with the latest release's tag and surface it in the subtitle ("previous: vX.Y.Z"). Cuts the version-bump path down to a single backspace + edit. Falls back gracefully if the repo has no releases yet, and reuses the cached latest release from the open releases overlay so the prefill is instant.

--- a/.changeset/release-mode-list-and-details.md
+++ b/.changeset/release-mode-list-and-details.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/ghui": minor
+---
+
+Add a Releases overlay reachable from the command palette ("Releases…"). Lists tags/names/badges (draft, pre-release, latest) for the active repository with pagination, and an inline details view showing the release body and assets. Open in browser (`o`) and copy URL (`y`) supported. Read-only for now — create/edit/delete arrives in a follow-up.

--- a/.changeset/release-mode-service-layer.md
+++ b/.changeset/release-mode-service-layer.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/ghui": minor
+---
+
+Add release domain types and `GitHubService` methods (list/get/create/update/delete releases, list tags/branches, default branch, generate release notes, list discussion categories) plus a matching mock layer. Foundation for the upcoming Release mode UI; no user-facing surface yet.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Terminal UI for keeping up with your open GitHub pull requests across repositories.
 
-`ghui` gives you one keyboard-driven place to review PR details, inspect diffs, leave diff comments, manage labels, toggle draft state, merge, open PRs in GitHub, and copy PR metadata without leaving the terminal.
+`ghui` gives you one keyboard-driven place to review PR details, inspect diffs, leave diff comments, manage labels, toggle draft state, merge, cut releases, open PRs in GitHub, and copy PR metadata without leaving the terminal.
 
 <img width="1420" height="856" alt="image" src="https://github.com/user-attachments/assets/5e560a4a-5887-4baa-a6d4-e1f4f0410c70" />
 
@@ -106,3 +106,30 @@ Review submission:
 - Press `enter` to move to the optional summary area.
 - Press `enter` again to submit, or `shift-enter` to insert a newline.
 - Press `esc` from the summary to return to action selection; press `esc` from action selection to cancel.
+
+## Releases
+
+Open the command palette and pick **Releases…** (or **New release…**) to manage releases for the active repository without leaving the terminal.
+
+In the releases overlay:
+
+- `j` / `k`, `gg` / `G`: navigate releases
+- `enter`: view a release (body + assets)
+- `n`: cut a new release
+- `e`: edit the selected release
+- `shift-d`: delete the selected release (with confirmation)
+- `o`: open in browser
+- `y`: copy URL
+- `]` / `r`: load more / refresh
+- `esc`: back to list / close
+
+In the release form:
+
+- `tab` / `shift-tab`: move between fields (tag, target, title, description, pre-release, latest)
+- `space` / `enter`: toggle the focused checkbox or tri-state
+- `ctrl-g`: generate release notes (only fills empty title and body, matching github.com)
+- `ctrl-s`: save as draft
+- `ctrl-↵`: publish (or save the edit when editing an existing release)
+- `esc`: cancel and return to the releases overlay
+
+Asset uploads are still done from the GitHub web UI for now — use `o` to jump to the draft release in the browser when you need to attach binaries.

--- a/plans/README.md
+++ b/plans/README.md
@@ -22,3 +22,4 @@ When a plan ships, leave the file in place and update the **Status** line so we 
 - [`sqlite-cache.md`](./sqlite-cache.md) — persistent SQLite cache for queues, hydrated details, comments, and optional diffs.
 - [`cache-v2.md`](./cache-v2.md) — audit-driven follow-up: diff cache, per-repo metadata persistence, `--cache-info` / `--cache-clear`.
 - [`comments-pane-redesign.md`](./comments-pane-redesign.md) — living design doc exploring how the Comments pane should render. Multiple styles, fully specced, iterate freely.
+- [`create-releases.md`](./create-releases.md) — create / edit / browse GitHub releases from the TUI, 1:1 with github.com's release form.

--- a/plans/create-releases.md
+++ b/plans/create-releases.md
@@ -97,7 +97,7 @@ Use REST via `gh api` (already the pattern in `GitHubService` for non-GraphQL fl
 In progress.
 
 - [x] Phase 1 — domain types, `GitHubService` methods, mock mirror, unit tests.
-- [ ] Phase 2 — release list + details view, `:release list` command, cache wiring.
+- [x] Phase 2 — release list + details overlay, command-palette entry, async loaders. (Persistent cache deferred; releases are refetched each time the modal opens.)
 - [ ] Phase 3 — create/edit form, tag autocomplete, generate-notes, draft/publish submit.
 - [ ] Phase 4 — delete confirm, footer hints, lazy discussion categories, doc updates.
 

--- a/plans/create-releases.md
+++ b/plans/create-releases.md
@@ -1,0 +1,104 @@
+# Create releases
+
+## Why
+
+ghui is a terminal UI for GitHub day-to-day work. Right now it covers PRs end-to-end but stops at merge — cutting a release still means switching to the browser or `gh release create` with a long argv. Releases are part of the same loop (merge → tag → publish notes), so they belong in the same TUI.
+
+The goal is **1:1 parity with the github.com "Create a new release" page** — anything you can do at `https://github.com/<owner>/<repo>/releases/new`, you can do from ghui without leaving the terminal.
+
+## What we'd ship
+
+A new "Release" mode reachable from the command palette (`:release` / `:release new`) and via a top-level keybinding (TBD). v1 surface area:
+
+1. **Repo selection.** Default to the repo of the currently-focused PR, or the repo most recently active. Allow `:release new <owner>/<repo>` to override.
+2. **A modal/screen that mirrors github.com's release form**, field-for-field:
+   - **Tag** — choose existing tag or type a new one. Autocomplete from existing tags. If new, also pick **target** (branch or commit SHA, default `main`/default branch).
+   - **Previous tag** — `auto` (default) or pick a specific tag, used by "Generate release notes".
+   - **Release title** — single-line, defaults to the tag name when empty (matches github.com).
+   - **Description** — multiline markdown editor (reuse `commentEditor.ts` patterns; `$EDITOR` integration like other long-text fields).
+   - **Generate release notes** — button/keybind that calls GitHub's autogenerate endpoint and inserts the result into title + description (only fills empty fields, matching web behaviour).
+   - **Set as a pre-release** — checkbox.
+   - **Set as the latest release** — tri-state: `auto` / `true` / `false` (matches API's `make_latest`).
+   - **Create a discussion for this release** — optional, with a discussion category picker (only shown if discussions are enabled on the repo).
+   - **Save draft** vs **Publish release** — two submit actions (`shift+S` draft, `enter`/`shift+P` publish), matching the two buttons on the page.
+3. **Existing-releases list** (`:releases` or just entering release mode without `new`):
+   - Lists releases for the active repo: tag, name, draft/prerelease/latest badges, published date, author.
+   - Open a release to view its body rendered, asset list, and metadata.
+   - Actions: edit (re-opens the same form prefilled), delete (with confirm), open in browser (`o`), copy URL (`y`).
+4. **Asset attachments — deferred.** v1 ships without binary upload. The form will note "Attach binaries via the web UI for now" with `o` to open the draft in the browser. Tracked under Out of scope below.
+
+## API mapping
+
+Use REST via `gh api` (already the pattern in `GitHubService` for non-GraphQL flows). All routes documented under https://docs.github.com/en/rest/releases.
+
+| Action | Endpoint |
+| --- | --- |
+| List releases | `GET /repos/{owner}/{repo}/releases` |
+| Get release | `GET /repos/{owner}/{repo}/releases/{id}` |
+| List tags (autocomplete) | `GET /repos/{owner}/{repo}/tags` (paginated) |
+| List branches (target) | `GET /repos/{owner}/{repo}/branches` |
+| Generate release notes | `POST /repos/{owner}/{repo}/releases/generate-notes` with `tag_name`, `previous_tag_name?`, `target_commitish?` |
+| List discussion categories | GraphQL `repository.discussionCategories` (REST has no endpoint) |
+| Create release | `POST /repos/{owner}/{repo}/releases` body: `tag_name`, `target_commitish`, `name`, `body`, `draft`, `prerelease`, `make_latest` (`"true"`/`"false"`/`"legacy"`), `discussion_category_name?`, `generate_release_notes?` |
+| Edit release | `PATCH /repos/{owner}/{repo}/releases/{id}` |
+| Delete release | `DELETE /repos/{owner}/{repo}/releases/{id}` |
+| List assets | `GET /repos/{owner}/{repo}/releases/{id}/assets` (read-only in v1) |
+
+`gh release create/edit/delete/view/list` exists too, but we already shell into `gh api` for fine-grained control elsewhere — sticking with REST keeps responses typed via `effect/Schema` like the rest of `GitHubService`.
+
+## Architecture sketch
+
+- **`src/domain.ts`**: new types `Release`, `ReleaseSummary`, `Tag`, `Branch`, `DiscussionCategory`, `MakeLatest = "true" | "false" | "legacy"`, `CreateReleaseInput`, `UpdateReleaseInput`.
+- **`src/services/GitHubService.ts`** new methods:
+  - `listReleases(repo, page): Effect<Page<ReleaseSummary>, …>`
+  - `getRelease(repo, id): Effect<Release, …>`
+  - `listTags(repo): Effect<readonly Tag[], …>`
+  - `listBranches(repo): Effect<readonly Branch[], …>`
+  - `generateReleaseNotes(repo, input): Effect<{ name: string; body: string }, …>`
+  - `listDiscussionCategories(repo): Effect<readonly DiscussionCategory[], …>`
+  - `createRelease(repo, input): Effect<Release, …>`
+  - `updateRelease(repo, id, input): Effect<Release, …>`
+  - `deleteRelease(repo, id): Effect<void, …>`
+- **`src/services/MockGitHubService.ts`**: in-memory mirror for tests/dev.
+- **`src/ui/ReleaseForm.tsx`** (new): the create/edit form. Reuses `singleLineInput.ts` for tag/title/target, `commentEditor.ts` for the body, and `modals.tsx` for the frame. Junction-row dividers per `AGENTS.md` UI conventions.
+- **`src/ui/ReleaseList.tsx`** (new): list view, mirrors `PullRequestList.tsx` styling.
+- **`src/ui/ReleaseDetails.tsx`** (new): detail view, mirrors `DetailsPane.tsx`.
+- **`src/appCommands.ts`**: register `:release new`, `:release list`, `:release edit <tag>`, `:release delete <tag>`.
+- **`src/App.tsx`**: new top-level mode `release` with sub-screens `list`/`form`/`details`. Probably swap out `PullRequestList`/`DetailsPane` while in this mode rather than splitting the layout.
+- **Cache.** Releases are cheap to list and change rarely; cache in `CacheService` keyed by `repo:releases` with a short TTL (5 min) and `repo:tags` (1 h). Bust on any local create/edit/delete.
+
+## UX details worth pinning down
+
+- **Form layout.** github.com stacks fields vertically; in the TUI we likely want a single column too, with `tab`/`shift-tab` to move between fields and `enter` to commit a value (matching how comment editing already feels). Generating notes is `g` in the form's footer hints.
+- **Tag autocomplete.** When typing a new tag, show a fuzzy-matched dropdown of existing tags. Picking one switches to "use existing tag" mode and hides the target field, matching the web UI.
+- **Latest tri-state UI.** Render as `( ) auto   ( ) yes   ( ) no` with `space` to advance.
+- **Confirm on publish vs draft.** `enter` from the body publishes; `shift+S` saves draft. We won't add an "are you sure" — github.com doesn't either.
+- **Markdown preview.** Out of scope for v1 — body is shown as raw markdown. Possibly add a side preview later.
+
+## Open questions
+
+1. **Top-level keybind.** PR list is the home screen today. Do releases get a sibling keybind (`R` from list?) or only command-palette entry? Lean: command-palette only in v1, add a keybind once we know how often it's used.
+2. **Cross-repo browsing.** The PR list is multi-repo (queue of search results). Should the release list be multi-repo too, or always single-repo? Lean: single-repo — releases are inherently per-repo and a unified feed is noisy.
+3. **Default target branch.** github.com defaults to the repo's default branch. We need an extra API call (`GET /repos/{owner}/{repo}`) to find it, or just default to `main` and let users override. Lean: fetch the default branch lazily — it's a tiny payload and matches the web's behaviour.
+4. **Generate-notes UX when fields are non-empty.** github.com only fills empty fields. Do we mirror exactly, or always overwrite with a confirm? Lean: mirror exactly; provide `shift+G` as "force regenerate" later if asked.
+5. **Discussion category fetch.** Only call when the user toggles "create a discussion" so we don't pay the GraphQL cost otherwise.
+6. **Asset uploads.** GitHub uses a separate uploads host (`uploads.github.com`) with binary multipart. `gh release upload` exists. Doable, but file pickers in a TUI are a real design exercise — punt to v2.
+
+## Out of scope (for v1)
+
+- Binary asset upload / management (delete, rename).
+- Markdown preview pane.
+- Release templating / per-repo defaults.
+- Notifications when a release publishes.
+- Cross-repo "all my releases" feed.
+
+## Status
+
+In progress.
+
+- [x] Phase 1 — domain types, `GitHubService` methods, mock mirror, unit tests.
+- [ ] Phase 2 — release list + details view, `:release list` command, cache wiring.
+- [ ] Phase 3 — create/edit form, tag autocomplete, generate-notes, draft/publish submit.
+- [ ] Phase 4 — delete confirm, footer hints, lazy discussion categories, doc updates.
+
+Decisions (from review): command-palette only in v1, single-repo release list, lazy default-branch fetch, generate-notes mirrors web (only fills empty fields), asset upload deferred to v2.

--- a/plans/create-releases.md
+++ b/plans/create-releases.md
@@ -94,11 +94,24 @@ Use REST via `gh api` (already the pattern in `GitHubService` for non-GraphQL fl
 
 ## Status
 
-In progress.
+Shipped.
 
 - [x] Phase 1 — domain types, `GitHubService` methods, mock mirror, unit tests.
-- [x] Phase 2 — release list + details overlay, command-palette entry, async loaders. (Persistent cache deferred; releases are refetched each time the modal opens.)
-- [x] Phase 3 — create/edit form with tag/target/title/body fields, pre-release toggle, latest tri-state, generate-notes (`ctrl-g`), draft (`ctrl-s`), publish (`ctrl-↵`). Tag autocomplete dropdown deferred to phase 4 (free-text input for now).
-- [ ] Phase 4 — delete confirm, footer hints, lazy discussion categories, doc updates.
+- [x] Phase 2 — release list + details overlay, command-palette entry, async loaders.
+- [x] Phase 3 — create/edit form with tag/target/title/body fields, pre-release toggle, latest tri-state, generate-notes, draft, publish.
+- [x] Phase 4 — delete with confirm (`shift-d`), README documentation.
 
 Decisions (from review): command-palette only in v1, single-repo release list, lazy default-branch fetch, generate-notes mirrors web (only fills empty fields), asset upload deferred to v2.
+
+## Follow-ups (deferred from v1)
+
+The v1 loop — browse, create, edit, publish/draft, delete — is complete. These were in the original plan but were deliberately not shipped because the form is already usable without them and they each carry meaningful design surface:
+
+- **Persistent cache.** Releases re-fetch each time the overlay opens. `CacheService` is heavily PR-shaped today; adding a generic `repo:releases` table is a real piece of work and not worth it until users complain about latency.
+- **Tag autocomplete dropdown.** The tag field is free-text. The form already calls `listTags` lazily on open isn’t wired in — the next step would be a fuzzy dropdown beneath the tag input that lets you reuse an existing tag (suppressing the target field on pick, like the web).
+- **Target branch picker.** Defaults to the repo’s default branch (lazy fetch already shipped); free-text otherwise. A picker dropdown would mirror the web more faithfully.
+- **Previous tag picker.** Currently always sent as `auto` to the generate-notes endpoint. A picker would let users force a specific previous tag.
+- **Discussion categories.** `listDiscussionCategories` and the `discussion_category_name` request field are wired in `GitHubService`, but the form has no UI to surface them. Add a fourth toggle row ("Create a discussion: [ ] enabled") that lazy-loads categories on toggle and exposes a single-select.
+- **Asset upload / management.** GitHub uses a separate uploads host with multipart binary; `gh release upload` exists. TUI file pickers are a real design exercise — punt to a follow-up plan.
+- **Markdown preview pane** for the release body.
+- **Cross-repo “all my releases” feed** (current overlay is single-repo, by design).

--- a/plans/create-releases.md
+++ b/plans/create-releases.md
@@ -98,7 +98,7 @@ In progress.
 
 - [x] Phase 1 — domain types, `GitHubService` methods, mock mirror, unit tests.
 - [x] Phase 2 — release list + details overlay, command-palette entry, async loaders. (Persistent cache deferred; releases are refetched each time the modal opens.)
-- [ ] Phase 3 — create/edit form, tag autocomplete, generate-notes, draft/publish submit.
+- [x] Phase 3 — create/edit form with tag/target/title/body fields, pre-release toggle, latest tri-state, generate-notes (`ctrl-g`), draft (`ctrl-s`), publish (`ctrl-↵`). Tag autocomplete dropdown deferred to phase 4 (free-text input for now).
 - [ ] Phase 4 — delete confirm, footer hints, lazy discussion categories, doc updates.
 
 Decisions (from review): command-palette only in v1, single-repo release list, lazy default-branch fetch, generate-notes mirrors web (only fills empty fields), asset upload deferred to v2.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,8 +24,11 @@ import {
 	type PullRequestMergeAction,
 	type PullRequestMergeMethod,
 	type PullRequestReviewComment,
+	type CreateReleaseInput,
+	type MakeLatest,
 	type Release,
 	type RepositoryMergeMethods,
+	type UpdateReleaseInput,
 	type SubmitPullRequestReviewInput,
 } from "./domain.js"
 import { allowedMergeMethodList, pullRequestMergeMethods } from "./domain.js"
@@ -111,6 +114,7 @@ import { FooterHints, initialRetryProgress, RetryProgress } from "./ui/FooterHin
 import { LoadingLogoPane } from "./ui/LoadingLogo.js"
 import { Divider, Filler, fitCell, PlainLine, SeparatorColumn } from "./ui/primitives.js"
 import { CommandPalette } from "./ui/CommandPalette.js"
+import { ReleaseForm } from "./ui/ReleaseForm.js"
 import { ReleasesModal } from "./ui/ReleasesModal.js"
 import {
 	ChangedFilesModal,
@@ -131,6 +135,7 @@ import {
 	initialModal,
 	initialOpenRepositoryModalState,
 	initialPullRequestStateModalState,
+	initialReleaseFormState,
 	initialReleasesModalState,
 	initialSubmitReviewModalState,
 	initialThemeModalState,
@@ -154,6 +159,8 @@ import {
 	type ModalTag,
 	type OpenRepositoryModalState,
 	type PullRequestStateModalState,
+	type ReleaseFormFocus,
+	type ReleaseFormState,
 	type ReleasesModalState,
 	type SubmitReviewModalState,
 	type ThemeModalState,
@@ -518,6 +525,27 @@ const getReleaseAtom = githubRuntime.fn<{ readonly repository: string; readonly 
 	GitHubService.use((github) => github.getRelease(input.repository, input.releaseId)),
 )
 const getLatestReleaseAtom = githubRuntime.fn<string>()((repository) => GitHubService.use((github) => github.getLatestRelease(repository)))
+const createReleaseAtom = githubRuntime.fn<{ readonly repository: string; readonly input: CreateReleaseInput }>()((args) =>
+	GitHubService.use((github) => github.createRelease(args.repository, args.input)),
+)
+const updateReleaseAtom = githubRuntime.fn<{ readonly repository: string; readonly releaseId: number; readonly input: UpdateReleaseInput }>()((args) =>
+	GitHubService.use((github) => github.updateRelease(args.repository, args.releaseId, args.input)),
+)
+const generateReleaseNotesAtom = githubRuntime.fn<{
+	readonly repository: string
+	readonly tagName: string
+	readonly previousTagName?: string
+	readonly targetCommitish?: string
+}>()((args) =>
+	GitHubService.use((github) =>
+		github.generateReleaseNotes(args.repository, {
+			tagName: args.tagName,
+			...(args.previousTagName !== undefined ? { previousTagName: args.previousTagName } : {}),
+			...(args.targetCommitish !== undefined ? { targetCommitish: args.targetCommitish } : {}),
+		}),
+	),
+)
+const getDefaultBranchAtom = githubRuntime.fn<string>()((repository) => GitHubService.use((github) => github.getDefaultBranch(repository)))
 
 const pickInitialMergeMethod = (allowed: RepositoryMergeMethods | null, preferred: PullRequestMergeMethod | undefined): PullRequestMergeMethod => {
 	if (!allowed) return preferred ?? pullRequestMergeMethods[0]
@@ -737,6 +765,7 @@ export const App = () => {
 	const commandPaletteActive = Modal.$is("CommandPalette")(activeModal)
 	const openRepositoryModalActive = Modal.$is("OpenRepository")(activeModal)
 	const releasesModalActive = Modal.$is("Releases")(activeModal)
+	const releaseFormActive = Modal.$is("ReleaseForm")(activeModal)
 	const labelModal: LabelModalState = labelModalActive ? activeModal : initialLabelModalState
 	const closeModal: CloseModalState = closeModalActive ? activeModal : initialCloseModalState
 	const pullRequestStateModal: PullRequestStateModalState = pullRequestStateModalActive ? activeModal : initialPullRequestStateModalState
@@ -750,6 +779,7 @@ export const App = () => {
 	const commandPalette: CommandPaletteState = commandPaletteActive ? activeModal : initialCommandPaletteState
 	const openRepositoryModal: OpenRepositoryModalState = openRepositoryModalActive ? activeModal : initialOpenRepositoryModalState
 	const releasesModal: ReleasesModalState = releasesModalActive ? activeModal : initialReleasesModalState
+	const releaseForm: ReleaseFormState = releaseFormActive ? activeModal : initialReleaseFormState
 	const makeModalSetter =
 		<Tag extends Exclude<ModalTag, "None">>(tag: Tag) =>
 		(next: ModalState<Tag> | ((prev: ModalState<Tag>) => ModalState<Tag>)) =>
@@ -775,6 +805,7 @@ export const App = () => {
 	const setCommandPalette = makeModalSetter("CommandPalette")
 	const setOpenRepositoryModal = makeModalSetter("OpenRepository")
 	const setReleasesModal = makeModalSetter("Releases")
+	const setReleaseForm = makeModalSetter("ReleaseForm")
 	const themeIdRef = useRef(themeId)
 	const themeModalRef = useRef(themeModal)
 	themeIdRef.current = themeId
@@ -821,6 +852,10 @@ export const App = () => {
 	const loadReleases = useAtomSet(listReleasesAtom, { mode: "promise" })
 	const loadRelease = useAtomSet(getReleaseAtom, { mode: "promise" })
 	const loadLatestRelease = useAtomSet(getLatestReleaseAtom, { mode: "promise" })
+	const submitCreateRelease = useAtomSet(createReleaseAtom, { mode: "promise" })
+	const submitUpdateRelease = useAtomSet(updateReleaseAtom, { mode: "promise" })
+	const fetchGenerateReleaseNotes = useAtomSet(generateReleaseNotesAtom, { mode: "promise" })
+	const fetchDefaultBranch = useAtomSet(getDefaultBranchAtom, { mode: "promise" })
 	const terminalWidth = width ?? 100
 	const terminalHeight = height ?? 24
 	const contentWidth = Math.max(1, terminalWidth)
@@ -2823,6 +2858,230 @@ export const App = () => {
 			.then(() => flashNotice(`Copied ${url}`))
 			.catch((error) => flashNotice(errorMessage(error)))
 	}
+
+	const loadDefaultBranchInto = (repository: string) => {
+		setReleaseForm((current) => (current.repository === repository ? { ...current, defaultBranchLoading: true } : current))
+		void fetchDefaultBranch(repository)
+			.then((branch) => {
+				setReleaseForm((current) => {
+					if (current.repository !== repository) return current
+					return { ...current, defaultBranch: branch, defaultBranchLoading: false }
+				})
+			})
+			.catch(() => {
+				setReleaseForm((current) => (current.repository === repository ? { ...current, defaultBranchLoading: false } : current))
+			})
+	}
+
+	const openReleaseFormForCreate = () => {
+		const repository = releasesModal.repository ?? selectedRepository
+		if (!repository) {
+			flashNotice("Open a repository first.")
+			return
+		}
+		setReleaseForm({
+			...initialReleaseFormState,
+			mode: "create",
+			repository,
+			focus: "tag",
+		})
+		loadDefaultBranchInto(repository)
+	}
+
+	const openReleaseFormForSelectedListItem = () => {
+		const current = releasesModal
+		if (!current.repository || current.releases.length === 0) return
+		const summary = current.releases[Math.max(0, Math.min(current.listSelectedIndex, current.releases.length - 1))]
+		if (!summary) return
+		setReleaseForm({
+			...initialReleaseFormState,
+			mode: "edit",
+			repository: current.repository,
+			editingReleaseId: summary.id,
+			originalTagName: summary.tagName,
+			tag: summary.tagName,
+			target: summary.targetCommitish,
+			title: summary.name ?? "",
+			body: { body: "", cursor: 0 },
+			isPrerelease: summary.isPrerelease,
+			makeLatest: summary.isPrerelease ? "false" : "true",
+			focus: "title",
+		})
+		loadDefaultBranchInto(current.repository)
+		// Hydrate body from full release.
+		void loadRelease({ repository: current.repository, releaseId: summary.id })
+			.then((release: Release) => {
+				setReleaseForm((prev) =>
+					prev.editingReleaseId === release.id ? { ...prev, body: { body: release.body ?? "", cursor: 0 }, target: release.targetCommitish || prev.target } : prev,
+				)
+			})
+			.catch((error) => flashNotice(errorMessage(error)))
+	}
+
+	const nextReleaseFormFocus = (delta: -1 | 1) => {
+		const order = ["tag", "target", "title", "body", "prerelease", "makeLatest"] as const
+		setReleaseForm((current) => {
+			const idx = order.indexOf(current.focus)
+			const next = order[(idx + delta + order.length) % order.length] as ReleaseFormFocus
+			return next === current.focus ? current : { ...current, focus: next }
+		})
+	}
+
+	const toggleReleaseFormField = () => {
+		setReleaseForm((current) => {
+			if (current.focus === "prerelease") return { ...current, isPrerelease: !current.isPrerelease }
+			if (current.focus === "makeLatest") {
+				const order: readonly MakeLatest[] = ["true", "false", "legacy"]
+				const idx = order.indexOf(current.makeLatest)
+				const next = order[(idx + 1) % order.length] as MakeLatest
+				return { ...current, makeLatest: next }
+			}
+			return current
+		})
+	}
+
+	const editReleaseFormBody = (mutator: (value: ReleaseFormState["body"]) => ReleaseFormState["body"]) => setReleaseForm((current) => ({ ...current, body: mutator(current.body) }))
+
+	const editReleaseFormSingleLine = (key: Parameters<typeof editSingleLineInput>[1]) => {
+		setReleaseForm((current) => {
+			const applyTo = (value: string) => editSingleLineInput(value, key) ?? value
+			switch (current.focus) {
+				case "tag":
+					return { ...current, tag: applyTo(current.tag) }
+				case "target":
+					return { ...current, target: applyTo(current.target) }
+				case "title":
+					return { ...current, title: applyTo(current.title) }
+				default:
+					return current
+			}
+		})
+	}
+
+	const insertReleaseFormText = (text: string) => {
+		if (text.length === 0) return
+		setReleaseForm((current) => {
+			if (current.focus === "body") return { ...current, body: insertText(current.body, text.replace(/\r\n?/g, "\n")) }
+			const flat = singleLineText(text)
+			if (flat.length === 0) return current
+			switch (current.focus) {
+				case "tag":
+					return { ...current, tag: current.tag + flat }
+				case "target":
+					return { ...current, target: current.target + flat }
+				case "title":
+					return { ...current, title: current.title + flat }
+				default:
+					return current
+			}
+		})
+	}
+
+	const submitReleaseForm = (asDraft: boolean) => {
+		const current = releaseForm
+		if (current.tag.trim().length === 0) {
+			setReleaseForm((prev) => ({ ...prev, error: "Tag is required.", focus: "tag" }))
+			return
+		}
+		if (current.submitting) return
+		const tag = current.tag.trim()
+		const target = current.target.trim().length > 0 ? current.target.trim() : (current.defaultBranch ?? "main")
+		const title = current.title.trim()
+		const body = current.body.body
+		setReleaseForm((prev) => ({ ...prev, submitting: true, error: null }))
+
+		const onError = (error: unknown) => {
+			const message = errorMessage(error)
+			setReleaseForm((prev) => ({ ...prev, submitting: false, error: message }))
+			flashNotice(message)
+		}
+
+		if (current.mode === "edit" && current.editingReleaseId !== null) {
+			const input: UpdateReleaseInput = {
+				tagName: tag,
+				targetCommitish: target,
+				name: title,
+				body,
+				draft: asDraft,
+				prerelease: current.isPrerelease,
+				makeLatest: current.makeLatest,
+			}
+			void submitUpdateRelease({ repository: current.repository, releaseId: current.editingReleaseId, input })
+				.then((release) => {
+					flashNotice(`Updated release ${release.tagName}`)
+					setReleaseForm(initialReleaseFormState)
+					if (releasesModalActive) {
+						setActiveModal(Modal.Releases({ ...releasesModal }))
+						refreshReleases()
+					} else {
+						closeActiveModal()
+					}
+				})
+				.catch(onError)
+			return
+		}
+
+		const input: CreateReleaseInput = {
+			tagName: tag,
+			targetCommitish: target,
+			name: title,
+			body,
+			draft: asDraft,
+			prerelease: current.isPrerelease,
+			makeLatest: current.makeLatest,
+		}
+		void submitCreateRelease({ repository: current.repository, input })
+			.then((release) => {
+				flashNotice(asDraft ? `Saved draft ${release.tagName}` : `Published ${release.tagName}`)
+				if (releasesModalActive && releasesModal.repository === current.repository) {
+					setActiveModal(Modal.Releases({ ...releasesModal }))
+					refreshReleases()
+				} else {
+					closeActiveModal()
+				}
+			})
+			.catch(onError)
+	}
+
+	const generateReleaseFormNotes = () => {
+		const current = releaseForm
+		const tag = current.tag.trim()
+		if (tag.length === 0) {
+			setReleaseForm((prev) => ({ ...prev, error: "Enter a tag before generating notes.", focus: "tag" }))
+			return
+		}
+		if (current.generatingNotes) return
+		setReleaseForm((prev) => ({ ...prev, generatingNotes: true, error: null }))
+		const args = {
+			repository: current.repository,
+			tagName: tag,
+			...(current.target.trim().length > 0 ? { targetCommitish: current.target.trim() } : {}),
+		}
+		void fetchGenerateReleaseNotes(args)
+			.then((notes) => {
+				setReleaseForm((prev) => ({
+					...prev,
+					generatingNotes: false,
+					title: prev.title.length === 0 ? notes.name : prev.title,
+					body: prev.body.body.length === 0 ? { body: notes.body, cursor: notes.body.length } : prev.body,
+				}))
+			})
+			.catch((error) => {
+				const message = errorMessage(error)
+				setReleaseForm((prev) => ({ ...prev, generatingNotes: false, error: message }))
+				flashNotice(message)
+			})
+	}
+
+	const cancelReleaseForm = () => {
+		setReleaseForm(initialReleaseFormState)
+		if (releasesModal.repository) {
+			setActiveModal(Modal.Releases({ ...releasesModal }))
+		} else {
+			closeActiveModal()
+		}
+	}
+
 	const insertPastedText = (text: string) => {
 		if (text.length === 0) return false
 		if (commandPaletteActive) {
@@ -2831,6 +3090,10 @@ export const App = () => {
 		}
 		if (openRepositoryModalActive) {
 			setOpenRepositoryModal((current) => ({ ...current, query: current.query + singleLineText(text), error: null }))
+			return true
+		}
+		if (releaseFormActive) {
+			insertReleaseFormText(text)
 			return true
 		}
 		if (themeModalActive && themeModal.filterMode) {
@@ -2879,6 +3142,7 @@ export const App = () => {
 		renderer,
 		commandPaletteActive,
 		openRepositoryModalActive,
+		releaseFormActive,
 		themeModalActive,
 		themeModal.filterMode,
 		commentModalActive,
@@ -2929,6 +3193,7 @@ export const App = () => {
 			openThemeModal,
 			openRepositoryPicker,
 			openReleasesModal,
+			openReleaseFormForCreate,
 			loadMorePullRequests,
 			switchViewTo,
 			openDetails: () => {
@@ -3136,6 +3401,7 @@ export const App = () => {
 		themeModalActive,
 		openRepositoryModalActive,
 		releasesModalActive,
+		releaseFormActive,
 		commentModalActive,
 		deleteCommentModalActive,
 		commandPaletteActive,
@@ -3150,6 +3416,7 @@ export const App = () => {
 			changedFilesModalActive ||
 			submitReviewModalActive ||
 			labelModalActive ||
+			releaseFormActive ||
 			filterMode ||
 			(themeModalActive && themeModal.filterMode),
 		closeModal: {
@@ -3242,6 +3509,36 @@ export const App = () => {
 			copyUrl: copySelectedReleaseUrl,
 			refresh: refreshReleases,
 			loadMore: loadMoreReleases,
+			newRelease: openReleaseFormForCreate,
+			editRelease: openReleaseFormForSelectedListItem,
+		},
+		releaseForm: {
+			bodyFocused: releaseForm.focus === "body",
+			toggleFocused: releaseForm.focus === "prerelease" || releaseForm.focus === "makeLatest",
+			canSubmit: releaseForm.tag.trim().length > 0 && !releaseForm.submitting,
+			canGenerate: releaseForm.tag.trim().length > 0 && !releaseForm.generatingNotes,
+			nextFocus: () => nextReleaseFormFocus(1),
+			previousFocus: () => nextReleaseFormFocus(-1),
+			cancel: cancelReleaseForm,
+			publish: () => submitReleaseForm(false),
+			saveDraft: () => submitReleaseForm(true),
+			generateNotes: generateReleaseFormNotes,
+			toggleField: toggleReleaseFormField,
+			insertNewline: () => editReleaseFormBody((state) => insertText(state, "\n")),
+			moveLeft: () => editReleaseFormBody(editorMoveLeft),
+			moveRight: () => editReleaseFormBody(editorMoveRight),
+			moveUp: () => editReleaseFormBody((state) => moveVertically(state, -1)),
+			moveDown: () => editReleaseFormBody((state) => moveVertically(state, 1)),
+			moveLineStart: () => editReleaseFormBody(moveLineStart),
+			moveLineEnd: () => editReleaseFormBody(moveLineEnd),
+			moveWordBackward: () => editReleaseFormBody(moveWordBackward),
+			moveWordForward: () => editReleaseFormBody(moveWordForward),
+			backspace: () => editReleaseFormBody(editorBackspace),
+			deleteForward: () => editReleaseFormBody(editorDeleteForward),
+			deleteWordBackward: () => editReleaseFormBody(deleteWordBackward),
+			deleteWordForward: () => editReleaseFormBody(deleteWordForward),
+			deleteToLineStart: () => editReleaseFormBody(deleteToLineStart),
+			deleteToLineEnd: () => editReleaseFormBody(deleteToLineEnd),
 		},
 		commentModal: {
 			closeModal: closeActiveModal,
@@ -3413,6 +3710,19 @@ export const App = () => {
 			return
 		}
 
+		if (releaseFormActive) {
+			if (releaseForm.focus === "body") {
+				const text = printableKeyText(key)
+				if (text) editReleaseFormBody((state) => insertText(state, text))
+				return
+			}
+			if (releaseForm.focus === "tag" || releaseForm.focus === "target" || releaseForm.focus === "title") {
+				if (isSingleLineInputKey(key)) editReleaseFormSingleLine(key)
+				return
+			}
+			return
+		}
+
 		if (changedFilesModalActive) {
 			if (isSingleLineInputKey(key)) {
 				setChangedFilesModal((current) => {
@@ -3576,6 +3886,11 @@ export const App = () => {
 	const releasesModalHeight = releasesLayout.height
 	const releasesModalLeft = releasesLayout.left
 	const releasesModalTop = releasesLayout.top
+	const releaseFormLayout = sizedModal(64, 96, 12, 28)
+	const releaseFormModalWidth = releaseFormLayout.width
+	const releaseFormModalHeight = releaseFormLayout.height
+	const releaseFormModalLeft = releaseFormLayout.left
+	const releaseFormModalTop = releaseFormLayout.top
 	const commandPaletteLayout = sizedModal(50, 88, 8, 24)
 	const commandPaletteWidth = commandPaletteLayout.width
 	const commandPaletteHeight = commandPaletteLayout.height
@@ -3943,6 +4258,16 @@ export const App = () => {
 					modalHeight={releasesModalHeight}
 					offsetLeft={releasesModalLeft}
 					offsetTop={releasesModalTop}
+					loadingIndicator={loadingIndicator}
+				/>
+			) : null}
+			{releaseFormActive ? (
+				<ReleaseForm
+					state={releaseForm}
+					modalWidth={releaseFormModalWidth}
+					modalHeight={releaseFormModalHeight}
+					offsetLeft={releaseFormModalLeft}
+					offsetTop={releaseFormModalTop}
 					loadingIndicator={loadingIndicator}
 				/>
 			) : null}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -116,6 +116,7 @@ import { Divider, Filler, fitCell, PlainLine, SeparatorColumn } from "./ui/primi
 import { CommandPalette } from "./ui/CommandPalette.js"
 import { ReleaseForm } from "./ui/ReleaseForm.js"
 import { ReleasesModal } from "./ui/ReleasesModal.js"
+import { DeleteReleaseModal } from "./ui/modals.js"
 import {
 	ChangedFilesModal,
 	CloseModal,
@@ -135,6 +136,7 @@ import {
 	initialModal,
 	initialOpenRepositoryModalState,
 	initialPullRequestStateModalState,
+	initialDeleteReleaseModalState,
 	initialReleaseFormState,
 	initialReleasesModalState,
 	initialSubmitReviewModalState,
@@ -159,6 +161,7 @@ import {
 	type ModalTag,
 	type OpenRepositoryModalState,
 	type PullRequestStateModalState,
+	type DeleteReleaseModalState,
 	type ReleaseFormFocus,
 	type ReleaseFormState,
 	type ReleasesModalState,
@@ -531,6 +534,9 @@ const createReleaseAtom = githubRuntime.fn<{ readonly repository: string; readon
 const updateReleaseAtom = githubRuntime.fn<{ readonly repository: string; readonly releaseId: number; readonly input: UpdateReleaseInput }>()((args) =>
 	GitHubService.use((github) => github.updateRelease(args.repository, args.releaseId, args.input)),
 )
+const deleteReleaseAtom = githubRuntime.fn<{ readonly repository: string; readonly releaseId: number }>()((args) =>
+	GitHubService.use((github) => github.deleteRelease(args.repository, args.releaseId)),
+)
 const generateReleaseNotesAtom = githubRuntime.fn<{
 	readonly repository: string
 	readonly tagName: string
@@ -766,6 +772,7 @@ export const App = () => {
 	const openRepositoryModalActive = Modal.$is("OpenRepository")(activeModal)
 	const releasesModalActive = Modal.$is("Releases")(activeModal)
 	const releaseFormActive = Modal.$is("ReleaseForm")(activeModal)
+	const deleteReleaseModalActive = Modal.$is("DeleteRelease")(activeModal)
 	const labelModal: LabelModalState = labelModalActive ? activeModal : initialLabelModalState
 	const closeModal: CloseModalState = closeModalActive ? activeModal : initialCloseModalState
 	const pullRequestStateModal: PullRequestStateModalState = pullRequestStateModalActive ? activeModal : initialPullRequestStateModalState
@@ -780,6 +787,7 @@ export const App = () => {
 	const openRepositoryModal: OpenRepositoryModalState = openRepositoryModalActive ? activeModal : initialOpenRepositoryModalState
 	const releasesModal: ReleasesModalState = releasesModalActive ? activeModal : initialReleasesModalState
 	const releaseForm: ReleaseFormState = releaseFormActive ? activeModal : initialReleaseFormState
+	const deleteReleaseModal: DeleteReleaseModalState = deleteReleaseModalActive ? activeModal : initialDeleteReleaseModalState
 	const makeModalSetter =
 		<Tag extends Exclude<ModalTag, "None">>(tag: Tag) =>
 		(next: ModalState<Tag> | ((prev: ModalState<Tag>) => ModalState<Tag>)) =>
@@ -806,6 +814,7 @@ export const App = () => {
 	const setOpenRepositoryModal = makeModalSetter("OpenRepository")
 	const setReleasesModal = makeModalSetter("Releases")
 	const setReleaseForm = makeModalSetter("ReleaseForm")
+	const setDeleteReleaseModal = makeModalSetter("DeleteRelease")
 	const themeIdRef = useRef(themeId)
 	const themeModalRef = useRef(themeModal)
 	themeIdRef.current = themeId
@@ -854,6 +863,7 @@ export const App = () => {
 	const loadLatestRelease = useAtomSet(getLatestReleaseAtom, { mode: "promise" })
 	const submitCreateRelease = useAtomSet(createReleaseAtom, { mode: "promise" })
 	const submitUpdateRelease = useAtomSet(updateReleaseAtom, { mode: "promise" })
+	const submitDeleteRelease = useAtomSet(deleteReleaseAtom, { mode: "promise" })
 	const fetchGenerateReleaseNotes = useAtomSet(generateReleaseNotesAtom, { mode: "promise" })
 	const fetchDefaultBranch = useAtomSet(getDefaultBranchAtom, { mode: "promise" })
 	const terminalWidth = width ?? 100
@@ -3082,6 +3092,77 @@ export const App = () => {
 		}
 	}
 
+	const openDeleteReleaseConfirm = () => {
+		const current = releasesModal
+		if (!current.repository || current.releases.length === 0) {
+			flashNotice("No release selected")
+			return
+		}
+		if (current.panel === "details") {
+			const release = current.detailsRelease
+			if (!release) {
+				flashNotice("No release loaded")
+				return
+			}
+			setDeleteReleaseModal({
+				repository: current.repository,
+				releaseId: release.id,
+				tagName: release.tagName,
+				name: release.name,
+				isDraft: release.isDraft,
+				running: false,
+				error: null,
+			})
+			return
+		}
+		const summary = current.releases[Math.max(0, Math.min(current.listSelectedIndex, current.releases.length - 1))]
+		if (!summary) return
+		setDeleteReleaseModal({
+			repository: current.repository,
+			releaseId: summary.id,
+			tagName: summary.tagName,
+			name: summary.name,
+			isDraft: summary.isDraft,
+			running: false,
+			error: null,
+		})
+	}
+
+	const confirmDeleteRelease = () => {
+		const current = deleteReleaseModal
+		if (!current.repository || current.releaseId === null || current.running) return
+		setDeleteReleaseModal((prev) => ({ ...prev, running: true, error: null }))
+		void submitDeleteRelease({ repository: current.repository, releaseId: current.releaseId })
+			.then(() => {
+				flashNotice(`Deleted release ${current.tagName}`)
+				// Optimistically drop from the list cache and bounce back to the releases overlay.
+				const nextReleases = releasesModal.releases.filter((r) => r.id !== current.releaseId)
+				const clampedIndex = Math.max(0, Math.min(releasesModal.listSelectedIndex, nextReleases.length - 1))
+				if (releasesModal.repository) {
+					setActiveModal(
+						Modal.Releases({
+							...releasesModal,
+							panel: "list",
+							releases: nextReleases,
+							listSelectedIndex: clampedIndex,
+							detailsRelease: null,
+							detailsReleaseId: null,
+							detailsLoading: false,
+							detailsError: null,
+							detailsScrollOffset: 0,
+						}),
+					)
+				} else {
+					closeActiveModal()
+				}
+			})
+			.catch((error) => {
+				const message = errorMessage(error)
+				setDeleteReleaseModal((prev) => ({ ...prev, running: false, error: message }))
+				flashNotice(message)
+			})
+	}
+
 	const insertPastedText = (text: string) => {
 		if (text.length === 0) return false
 		if (commandPaletteActive) {
@@ -3402,6 +3483,7 @@ export const App = () => {
 		openRepositoryModalActive,
 		releasesModalActive,
 		releaseFormActive,
+		deleteReleaseModalActive,
 		commentModalActive,
 		deleteCommentModalActive,
 		commandPaletteActive,
@@ -3511,6 +3593,16 @@ export const App = () => {
 			loadMore: loadMoreReleases,
 			newRelease: openReleaseFormForCreate,
 			editRelease: openReleaseFormForSelectedListItem,
+			deleteRelease: openDeleteReleaseConfirm,
+		},
+		deleteReleaseModal: {
+			running: deleteReleaseModal.running,
+			closeModal: () => {
+				setDeleteReleaseModal(initialDeleteReleaseModalState)
+				if (releasesModal.repository) setActiveModal(Modal.Releases({ ...releasesModal }))
+				else closeActiveModal()
+			},
+			confirmDelete: confirmDeleteRelease,
 		},
 		releaseForm: {
 			bodyFocused: releaseForm.focus === "body",
@@ -3891,6 +3983,11 @@ export const App = () => {
 	const releaseFormModalHeight = releaseFormLayout.height
 	const releaseFormModalLeft = releaseFormLayout.left
 	const releaseFormModalTop = releaseFormLayout.top
+	const deleteReleaseLayout = sizedModal(46, 68, 12, 12)
+	const deleteReleaseModalWidth = deleteReleaseLayout.width
+	const deleteReleaseModalHeight = deleteReleaseLayout.height
+	const deleteReleaseModalLeft = deleteReleaseLayout.left
+	const deleteReleaseModalTop = deleteReleaseLayout.top
 	const commandPaletteLayout = sizedModal(50, 88, 8, 24)
 	const commandPaletteWidth = commandPaletteLayout.width
 	const commandPaletteHeight = commandPaletteLayout.height
@@ -4268,6 +4365,16 @@ export const App = () => {
 					modalHeight={releaseFormModalHeight}
 					offsetLeft={releaseFormModalLeft}
 					offsetTop={releaseFormModalTop}
+					loadingIndicator={loadingIndicator}
+				/>
+			) : null}
+			{deleteReleaseModalActive ? (
+				<DeleteReleaseModal
+					state={deleteReleaseModal}
+					modalWidth={deleteReleaseModalWidth}
+					modalHeight={deleteReleaseModalHeight}
+					offsetLeft={deleteReleaseModalLeft}
+					offsetTop={deleteReleaseModalTop}
 					loadingIndicator={loadingIndicator}
 				/>
 			) : null}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import {
 	type PullRequestMergeAction,
 	type PullRequestMergeMethod,
 	type PullRequestReviewComment,
+	type Release,
 	type RepositoryMergeMethods,
 	type SubmitPullRequestReviewInput,
 } from "./domain.js"
@@ -110,6 +111,7 @@ import { FooterHints, initialRetryProgress, RetryProgress } from "./ui/FooterHin
 import { LoadingLogoPane } from "./ui/LoadingLogo.js"
 import { Divider, Filler, fitCell, PlainLine, SeparatorColumn } from "./ui/primitives.js"
 import { CommandPalette } from "./ui/CommandPalette.js"
+import { ReleasesModal } from "./ui/ReleasesModal.js"
 import {
 	ChangedFilesModal,
 	CloseModal,
@@ -129,6 +131,7 @@ import {
 	initialModal,
 	initialOpenRepositoryModalState,
 	initialPullRequestStateModalState,
+	initialReleasesModalState,
 	initialSubmitReviewModalState,
 	initialThemeModalState,
 	LabelModal,
@@ -151,6 +154,7 @@ import {
 	type ModalTag,
 	type OpenRepositoryModalState,
 	type PullRequestStateModalState,
+	type ReleasesModalState,
 	type SubmitReviewModalState,
 	type ThemeModalState,
 } from "./ui/modals.js"
@@ -507,6 +511,13 @@ const submitPullRequestReviewAtom = githubRuntime.fn<SubmitPullRequestReviewInpu
 const copyToClipboardAtom = githubRuntime.fn<string>()((text) => Clipboard.use((clipboard) => clipboard.copy(text)))
 const openInBrowserAtom = githubRuntime.fn<PullRequestItem>()((pullRequest) => BrowserOpener.use((browser) => browser.openPullRequest(pullRequest)))
 const openUrlAtom = githubRuntime.fn<string>()((url) => BrowserOpener.use((browser) => browser.openUrl(url)))
+const listReleasesAtom = githubRuntime.fn<{ readonly repository: string; readonly page: number }>()((input) =>
+	GitHubService.use((github) => github.listReleases(input.repository, input.page)),
+)
+const getReleaseAtom = githubRuntime.fn<{ readonly repository: string; readonly releaseId: number }>()((input) =>
+	GitHubService.use((github) => github.getRelease(input.repository, input.releaseId)),
+)
+const getLatestReleaseAtom = githubRuntime.fn<string>()((repository) => GitHubService.use((github) => github.getLatestRelease(repository)))
 
 const pickInitialMergeMethod = (allowed: RepositoryMergeMethods | null, preferred: PullRequestMergeMethod | undefined): PullRequestMergeMethod => {
 	if (!allowed) return preferred ?? pullRequestMergeMethods[0]
@@ -725,6 +736,7 @@ export const App = () => {
 	const themeModalActive = Modal.$is("Theme")(activeModal)
 	const commandPaletteActive = Modal.$is("CommandPalette")(activeModal)
 	const openRepositoryModalActive = Modal.$is("OpenRepository")(activeModal)
+	const releasesModalActive = Modal.$is("Releases")(activeModal)
 	const labelModal: LabelModalState = labelModalActive ? activeModal : initialLabelModalState
 	const closeModal: CloseModalState = closeModalActive ? activeModal : initialCloseModalState
 	const pullRequestStateModal: PullRequestStateModalState = pullRequestStateModalActive ? activeModal : initialPullRequestStateModalState
@@ -737,6 +749,7 @@ export const App = () => {
 	const themeModal: ThemeModalState = themeModalActive ? activeModal : initialThemeModalState
 	const commandPalette: CommandPaletteState = commandPaletteActive ? activeModal : initialCommandPaletteState
 	const openRepositoryModal: OpenRepositoryModalState = openRepositoryModalActive ? activeModal : initialOpenRepositoryModalState
+	const releasesModal: ReleasesModalState = releasesModalActive ? activeModal : initialReleasesModalState
 	const makeModalSetter =
 		<Tag extends Exclude<ModalTag, "None">>(tag: Tag) =>
 		(next: ModalState<Tag> | ((prev: ModalState<Tag>) => ModalState<Tag>)) =>
@@ -761,6 +774,7 @@ export const App = () => {
 	const setThemeModal = makeModalSetter("Theme")
 	const setCommandPalette = makeModalSetter("CommandPalette")
 	const setOpenRepositoryModal = makeModalSetter("OpenRepository")
+	const setReleasesModal = makeModalSetter("Releases")
 	const themeIdRef = useRef(themeId)
 	const themeModalRef = useRef(themeModal)
 	themeIdRef.current = themeId
@@ -804,6 +818,9 @@ export const App = () => {
 	const copyToClipboard = useAtomSet(copyToClipboardAtom, { mode: "promise" })
 	const openInBrowser = useAtomSet(openInBrowserAtom, { mode: "promise" })
 	const openUrl = useAtomSet(openUrlAtom, { mode: "promise" })
+	const loadReleases = useAtomSet(listReleasesAtom, { mode: "promise" })
+	const loadRelease = useAtomSet(getReleaseAtom, { mode: "promise" })
+	const loadLatestRelease = useAtomSet(getLatestReleaseAtom, { mode: "promise" })
 	const terminalWidth = width ?? 100
 	const terminalHeight = height ?? 24
 	const contentWidth = Math.max(1, terminalWidth)
@@ -2655,6 +2672,157 @@ export const App = () => {
 		switchViewTo({ _tag: "Repository", repository })
 		flashNotice(`Opened ${repository}`)
 	}
+
+	const loadReleasesPage = (repository: string, page: number, mode: "initial" | "refresh" | "more") => {
+		if (mode === "initial" || mode === "refresh") {
+			setReleasesModal((current) => ({ ...current, loading: true, error: null }))
+		} else {
+			setReleasesModal((current) => ({ ...current, loadingMore: true, error: null }))
+		}
+		void loadReleases({ repository, page })
+			.then((result) => {
+				setReleasesModal((current) => {
+					if (current.repository !== repository) return current
+					const items = mode === "more" ? [...current.releases, ...result.items] : result.items
+					return {
+						...current,
+						releases: items,
+						loading: false,
+						loadingMore: false,
+						hasNextPage: result.hasNextPage,
+						nextPage: result.nextPage,
+						listSelectedIndex: mode === "more" ? current.listSelectedIndex : 0,
+						error: null,
+					}
+				})
+			})
+			.catch((error) => {
+				const message = errorMessage(error)
+				setReleasesModal((current) => (current.repository === repository ? { ...current, loading: false, loadingMore: false, error: message } : current))
+				flashNotice(message)
+			})
+		if (mode === "initial" || mode === "refresh") {
+			void loadLatestRelease(repository)
+				.then((latest) => {
+					setReleasesModal((current) => (current.repository === repository ? { ...current, latestReleaseId: latest?.id ?? null } : current))
+				})
+				.catch(() => {
+					/* non-fatal — "latest" badge just stays absent */
+				})
+		}
+	}
+
+	const openReleasesModal = () => {
+		if (!selectedRepository) {
+			flashNotice("Open a repository first.")
+			return
+		}
+		setReleasesModal({ ...initialReleasesModalState, repository: selectedRepository, loading: true })
+		loadReleasesPage(selectedRepository, 1, "initial")
+	}
+
+	const refreshReleases = () => {
+		if (!releasesModal.repository) return
+		loadReleasesPage(releasesModal.repository, 1, "refresh")
+	}
+
+	const loadMoreReleases = () => {
+		if (!releasesModal.repository || !releasesModal.hasNextPage || releasesModal.loadingMore) return
+		const page = releasesModal.nextPage ?? 2
+		loadReleasesPage(releasesModal.repository, page, "more")
+	}
+
+	const moveReleaseSelection = (delta: -1 | 1) => {
+		setReleasesModal((current) => {
+			if (current.releases.length === 0) return current
+			const next = Math.max(0, Math.min(current.releases.length - 1, current.listSelectedIndex + delta))
+			return next === current.listSelectedIndex ? current : { ...current, listSelectedIndex: next }
+		})
+	}
+
+	const jumpReleaseSelection = (target: "top" | "bottom") => {
+		setReleasesModal((current) => {
+			if (current.releases.length === 0) return current
+			const index = target === "top" ? 0 : current.releases.length - 1
+			return index === current.listSelectedIndex ? current : { ...current, listSelectedIndex: index }
+		})
+	}
+
+	const openSelectedReleaseDetails = () => {
+		const current = releasesModal
+		if (!current.repository || current.releases.length === 0) return
+		const selected = current.releases[Math.max(0, Math.min(current.listSelectedIndex, current.releases.length - 1))]
+		if (!selected) return
+		setReleasesModal((prev) => ({
+			...prev,
+			panel: "details",
+			detailsReleaseId: selected.id,
+			detailsRelease: null,
+			detailsLoading: true,
+			detailsError: null,
+			detailsScrollOffset: 0,
+		}))
+		void loadRelease({ repository: current.repository, releaseId: selected.id })
+			.then((release: Release) => {
+				setReleasesModal((prev) => (prev.detailsReleaseId === release.id ? { ...prev, detailsRelease: release, detailsLoading: false, detailsError: null } : prev))
+			})
+			.catch((error) => {
+				const message = errorMessage(error)
+				setReleasesModal((prev) => (prev.detailsReleaseId === selected.id ? { ...prev, detailsLoading: false, detailsError: message } : prev))
+			})
+	}
+
+	const scrollReleaseDetails = (delta: number) => {
+		setReleasesModal((current) => {
+			if (current.panel !== "details") return current
+			const next = Math.max(0, current.detailsScrollOffset + delta)
+			return next === current.detailsScrollOffset ? current : { ...current, detailsScrollOffset: next }
+		})
+	}
+
+	const closeOrBackReleases = () => {
+		if (releasesModal.panel === "details") {
+			setReleasesModal((current) => ({
+				...current,
+				panel: "list",
+				detailsRelease: null,
+				detailsReleaseId: null,
+				detailsLoading: false,
+				detailsError: null,
+				detailsScrollOffset: 0,
+			}))
+			return
+		}
+		closeActiveModal()
+	}
+
+	const selectedReleaseUrl = (): string | null => {
+		if (releasesModal.panel === "details") return releasesModal.detailsRelease?.htmlUrl ?? null
+		const selected = releasesModal.releases[releasesModal.listSelectedIndex]
+		return selected?.htmlUrl ?? null
+	}
+
+	const openSelectedReleaseInBrowser = () => {
+		const url = selectedReleaseUrl()
+		if (!url) {
+			flashNotice("No release selected")
+			return
+		}
+		void openUrl(url)
+			.then(() => flashNotice(`Opened ${url}`))
+			.catch((error) => flashNotice(errorMessage(error)))
+	}
+
+	const copySelectedReleaseUrl = () => {
+		const url = selectedReleaseUrl()
+		if (!url) {
+			flashNotice("No release selected")
+			return
+		}
+		void copyToClipboard(url)
+			.then(() => flashNotice(`Copied ${url}`))
+			.catch((error) => flashNotice(errorMessage(error)))
+	}
 	const insertPastedText = (text: string) => {
 		if (text.length === 0) return false
 		if (commandPaletteActive) {
@@ -2760,6 +2928,7 @@ export const App = () => {
 			},
 			openThemeModal,
 			openRepositoryPicker,
+			openReleasesModal,
 			loadMorePullRequests,
 			switchViewTo,
 			openDetails: () => {
@@ -2966,6 +3135,7 @@ export const App = () => {
 		labelModalActive,
 		themeModalActive,
 		openRepositoryModalActive,
+		releasesModalActive,
 		commentModalActive,
 		deleteCommentModalActive,
 		commandPaletteActive,
@@ -3055,6 +3225,23 @@ export const App = () => {
 		openRepositoryModal: {
 			closeModal: closeActiveModal,
 			openFromInput: openRepositoryFromInput,
+		},
+		releasesModal: {
+			panel: releasesModal.panel,
+			hasReleases: releasesModal.releases.length > 0,
+			hasSelection: releasesModal.releases.length > 0,
+			hasNextPage: releasesModal.hasNextPage,
+			loadingMore: releasesModal.loadingMore,
+			closeOrBack: closeOrBackReleases,
+			moveSelection: moveReleaseSelection,
+			jumpSelection: jumpReleaseSelection,
+			openDetails: openSelectedReleaseDetails,
+			scrollDetails: (delta) => scrollReleaseDetails(delta),
+			scrollDetailsPage: (delta) => scrollReleaseDetails(delta * 10),
+			openInBrowser: openSelectedReleaseInBrowser,
+			copyUrl: copySelectedReleaseUrl,
+			refresh: refreshReleases,
+			loadMore: loadMoreReleases,
 		},
 		commentModal: {
 			closeModal: closeActiveModal,
@@ -3384,6 +3571,11 @@ export const App = () => {
 	const openRepositoryModalHeight = openRepositoryLayout.height
 	const openRepositoryModalLeft = openRepositoryLayout.left
 	const openRepositoryModalTop = openRepositoryLayout.top
+	const releasesLayout = sizedModal(70, 110, 18, 28)
+	const releasesModalWidth = releasesLayout.width
+	const releasesModalHeight = releasesLayout.height
+	const releasesModalLeft = releasesLayout.left
+	const releasesModalTop = releasesLayout.top
 	const commandPaletteLayout = sizedModal(50, 88, 8, 24)
 	const commandPaletteWidth = commandPaletteLayout.width
 	const commandPaletteHeight = commandPaletteLayout.height
@@ -3742,6 +3934,16 @@ export const App = () => {
 					modalHeight={openRepositoryModalHeight}
 					offsetLeft={openRepositoryModalLeft}
 					offsetTop={openRepositoryModalTop}
+				/>
+			) : null}
+			{releasesModalActive ? (
+				<ReleasesModal
+					state={releasesModal}
+					modalWidth={releasesModalWidth}
+					modalHeight={releasesModalHeight}
+					offsetLeft={releasesModalLeft}
+					offsetTop={releasesModalTop}
+					loadingIndicator={loadingIndicator}
 				/>
 			) : null}
 			{commandPaletteActive ? (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2889,13 +2889,36 @@ export const App = () => {
 			flashNotice("Open a repository first.")
 			return
 		}
+		// Reuse the latest release we already have cached on the releases overlay
+		// (if any) so the tag field can prefill instantly without an extra fetch.
+		const cachedLatest = releasesModal.repository === repository ? (releasesModal.releases.find((r) => r.id === releasesModal.latestReleaseId) ?? null) : null
 		setReleaseForm({
 			...initialReleaseFormState,
 			mode: "create",
 			repository,
 			focus: "tag",
+			tag: cachedLatest?.tagName ?? "",
+			latestTagName: cachedLatest?.tagName ?? null,
 		})
 		loadDefaultBranchInto(repository)
+		// Refresh in the background; only overwrite the tag field if the user
+		// hasn't typed anything yet (matches the GitHub web UI's "only fill empty
+		// fields" behaviour for generate-notes).
+		void loadLatestRelease(repository)
+			.then((latest) => {
+				if (!latest) return
+				setReleaseForm((current) => {
+					if (current.repository !== repository || current.mode !== "create") return current
+					return {
+						...current,
+						latestTagName: latest.tagName,
+						tag: current.tag.length === 0 ? latest.tagName : current.tag,
+					}
+				})
+			})
+			.catch(() => {
+				/* non-fatal — the form is still usable without the previous tag hint */
+			})
 	}
 
 	const openReleaseFormForSelectedListItem = () => {

--- a/src/appCommands.ts
+++ b/src/appCommands.ts
@@ -12,6 +12,7 @@ interface AppCommandActions {
 	readonly openThemeModal: () => void
 	readonly openRepositoryPicker: () => void
 	readonly openReleasesModal: () => void
+	readonly openReleaseFormForCreate: () => void
 	readonly loadMorePullRequests: () => void
 	readonly switchViewTo: (view: PullRequestView) => void
 	readonly openDetails: () => void
@@ -184,6 +185,15 @@ export const buildAppCommands = ({
 			keywords: ["release", "tag", "changelog", "version"],
 			disabledReason: selectedRepository ? null : "Open a repository first.",
 			run: actions.openReleasesModal,
+		}),
+		defineCommand({
+			id: "release.new",
+			title: "New release\u2026",
+			scope: "View",
+			subtitle: selectedRepository ? `Cut a release in ${selectedRepository}` : "Open a repository first",
+			keywords: ["release", "publish", "draft", "tag", "new"],
+			disabledReason: selectedRepository ? null : "Open a repository first.",
+			run: actions.openReleaseFormForCreate,
 		}),
 		...activeViews.map((view) =>
 			defineCommand({

--- a/src/appCommands.ts
+++ b/src/appCommands.ts
@@ -183,7 +183,6 @@ export const buildAppCommands = ({
 			scope: "View",
 			subtitle: selectedRepository ? `Browse releases in ${selectedRepository}` : "Open a repository first",
 			keywords: ["release", "tag", "changelog", "version"],
-			disabledReason: selectedRepository ? null : "Open a repository first.",
 			run: actions.openReleasesModal,
 		}),
 		defineCommand({
@@ -192,7 +191,6 @@ export const buildAppCommands = ({
 			scope: "View",
 			subtitle: selectedRepository ? `Cut a release in ${selectedRepository}` : "Open a repository first",
 			keywords: ["release", "publish", "draft", "tag", "new"],
-			disabledReason: selectedRepository ? null : "Open a repository first.",
 			run: actions.openReleaseFormForCreate,
 		}),
 		...activeViews.map((view) =>

--- a/src/appCommands.ts
+++ b/src/appCommands.ts
@@ -11,6 +11,7 @@ interface AppCommandActions {
 	readonly clearFilter: () => void
 	readonly openThemeModal: () => void
 	readonly openRepositoryPicker: () => void
+	readonly openReleasesModal: () => void
 	readonly loadMorePullRequests: () => void
 	readonly switchViewTo: (view: PullRequestView) => void
 	readonly openDetails: () => void
@@ -174,6 +175,15 @@ export const buildAppCommands = ({
 			subtitle: selectedRepository ? `Current repository: ${selectedRepository}` : "Enter owner/name or a GitHub URL",
 			keywords: ["repo", "repository", "owner", "github"],
 			run: actions.openRepositoryPicker,
+		}),
+		defineCommand({
+			id: "release.list",
+			title: "Releases\u2026",
+			scope: "View",
+			subtitle: selectedRepository ? `Browse releases in ${selectedRepository}` : "Open a repository first",
+			keywords: ["release", "tag", "changelog", "version"],
+			disabledReason: selectedRepository ? null : "Open a repository first.",
+			run: actions.openReleasesModal,
 		}),
 		...activeViews.map((view) =>
 			defineCommand({

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -167,6 +167,104 @@ export interface ListPullRequestPageInput {
 	readonly pageSize: number
 }
 
+export const makeLatestValues = ["true", "false", "legacy"] as const
+export type MakeLatest = (typeof makeLatestValues)[number]
+
+export interface Tag {
+	readonly name: string
+	readonly commitSha: string
+}
+
+export interface Branch {
+	readonly name: string
+	readonly commitSha: string
+	readonly isDefault: boolean
+}
+
+export interface DiscussionCategory {
+	readonly id: string
+	readonly name: string
+	readonly slug: string
+	readonly emoji: string | null
+}
+
+export interface ReleaseAuthor {
+	readonly login: string
+}
+
+export interface ReleaseAsset {
+	readonly id: number
+	readonly name: string
+	readonly label: string | null
+	readonly size: number
+	readonly downloadCount: number
+	readonly contentType: string
+	readonly downloadUrl: string
+	readonly htmlUrl: string | null
+	readonly createdAt: Date | null
+	readonly updatedAt: Date | null
+}
+
+export interface ReleaseSummary {
+	readonly id: number
+	readonly tagName: string
+	readonly name: string | null
+	readonly isDraft: boolean
+	readonly isPrerelease: boolean
+	readonly targetCommitish: string
+	readonly author: ReleaseAuthor | null
+	readonly createdAt: Date | null
+	readonly publishedAt: Date | null
+	readonly htmlUrl: string
+}
+
+export interface Release extends ReleaseSummary {
+	readonly body: string
+	readonly assets: readonly ReleaseAsset[]
+	readonly discussionUrl: string | null
+}
+
+export interface ReleasePage {
+	readonly items: readonly ReleaseSummary[]
+	readonly hasNextPage: boolean
+	readonly nextPage: number | null
+}
+
+export interface CreateReleaseInput {
+	readonly tagName: string
+	readonly targetCommitish?: string
+	readonly name?: string
+	readonly body?: string
+	readonly draft?: boolean
+	readonly prerelease?: boolean
+	readonly makeLatest?: MakeLatest
+	readonly discussionCategoryName?: string
+	readonly generateReleaseNotes?: boolean
+}
+
+export interface UpdateReleaseInput {
+	readonly tagName?: string
+	readonly targetCommitish?: string
+	readonly name?: string
+	readonly body?: string
+	readonly draft?: boolean
+	readonly prerelease?: boolean
+	readonly makeLatest?: MakeLatest
+	readonly discussionCategoryName?: string
+}
+
+export interface GenerateReleaseNotesInput {
+	readonly tagName: string
+	readonly previousTagName?: string
+	readonly targetCommitish?: string
+	readonly configurationFilePath?: string
+}
+
+export interface GeneratedReleaseNotes {
+	readonly name: string
+	readonly body: string
+}
+
 export interface PullRequestMergeInfo {
 	readonly repository: string
 	readonly number: number

--- a/src/keymap/all.ts
+++ b/src/keymap/all.ts
@@ -14,6 +14,7 @@ import { listNavKeymap, type ListNavCtx } from "./listNav.ts"
 import { mergeModalKeymap, type MergeModalCtx } from "./mergeModal.ts"
 import { openRepositoryModalKeymap, type OpenRepositoryModalCtx } from "./openRepositoryModal.ts"
 import { pullRequestStateModalKeymap, type PullRequestStateModalCtx } from "./pullRequestStateModal.ts"
+import { releaseFormKeymap, type ReleaseFormCtx } from "./releaseForm.ts"
 import { releasesModalKeymap, type ReleasesModalCtx } from "./releasesModal.ts"
 import { submitReviewModalKeymap, type SubmitReviewModalCtx } from "./submitReviewModal.ts"
 import { themeModalKeymap, type ThemeModalCtx } from "./themeModal.ts"
@@ -30,6 +31,7 @@ export interface AppCtx {
 	readonly themeModalActive: boolean
 	readonly openRepositoryModalActive: boolean
 	readonly releasesModalActive: boolean
+	readonly releaseFormActive: boolean
 	readonly commentModalActive: boolean
 	readonly deleteCommentModalActive: boolean
 	readonly commandPaletteActive: boolean
@@ -53,6 +55,7 @@ export interface AppCtx {
 	readonly themeModal: ThemeModalCtx
 	readonly openRepositoryModal: OpenRepositoryModalCtx
 	readonly releasesModal: ReleasesModalCtx
+	readonly releaseForm: ReleaseFormCtx
 	readonly commentModal: CommentModalCtx
 	readonly deleteCommentModal: DeleteCommentModalCtx
 	readonly commandPalette: CommandPaletteCtx
@@ -80,6 +83,7 @@ const modalActive = (a: AppCtx): boolean =>
 	a.themeModalActive ||
 	a.openRepositoryModalActive ||
 	a.releasesModalActive ||
+	a.releaseFormActive ||
 	a.commentModalActive ||
 	a.deleteCommentModalActive ||
 	a.commandPaletteActive
@@ -116,6 +120,7 @@ export const appKeymap = App(
 	themeModalKeymap.scope((a) => a.themeModalActive && a.themeModal),
 	openRepositoryModalKeymap.scope((a) => a.openRepositoryModalActive && a.openRepositoryModal),
 	releasesModalKeymap.scope((a) => a.releasesModalActive && a.releasesModal),
+	releaseFormKeymap.scope((a) => a.releaseFormActive && a.releaseForm),
 	commentModalKeymap.scope((a) => a.commentModalActive && a.commentModal),
 	deleteCommentModalKeymap.scope((a) => a.deleteCommentModalActive && a.deleteCommentModal),
 	commandPaletteKeymap.scope((a) => a.commandPaletteActive && a.commandPalette),

--- a/src/keymap/all.ts
+++ b/src/keymap/all.ts
@@ -14,6 +14,7 @@ import { listNavKeymap, type ListNavCtx } from "./listNav.ts"
 import { mergeModalKeymap, type MergeModalCtx } from "./mergeModal.ts"
 import { openRepositoryModalKeymap, type OpenRepositoryModalCtx } from "./openRepositoryModal.ts"
 import { pullRequestStateModalKeymap, type PullRequestStateModalCtx } from "./pullRequestStateModal.ts"
+import { releasesModalKeymap, type ReleasesModalCtx } from "./releasesModal.ts"
 import { submitReviewModalKeymap, type SubmitReviewModalCtx } from "./submitReviewModal.ts"
 import { themeModalKeymap, type ThemeModalCtx } from "./themeModal.ts"
 
@@ -28,6 +29,7 @@ export interface AppCtx {
 	readonly labelModalActive: boolean
 	readonly themeModalActive: boolean
 	readonly openRepositoryModalActive: boolean
+	readonly releasesModalActive: boolean
 	readonly commentModalActive: boolean
 	readonly deleteCommentModalActive: boolean
 	readonly commandPaletteActive: boolean
@@ -50,6 +52,7 @@ export interface AppCtx {
 	readonly labelModal: LabelModalCtx
 	readonly themeModal: ThemeModalCtx
 	readonly openRepositoryModal: OpenRepositoryModalCtx
+	readonly releasesModal: ReleasesModalCtx
 	readonly commentModal: CommentModalCtx
 	readonly deleteCommentModal: DeleteCommentModalCtx
 	readonly commandPalette: CommandPaletteCtx
@@ -76,6 +79,7 @@ const modalActive = (a: AppCtx): boolean =>
 	a.labelModalActive ||
 	a.themeModalActive ||
 	a.openRepositoryModalActive ||
+	a.releasesModalActive ||
 	a.commentModalActive ||
 	a.deleteCommentModalActive ||
 	a.commandPaletteActive
@@ -111,6 +115,7 @@ export const appKeymap = App(
 	labelModalKeymap.scope((a) => a.labelModalActive && a.labelModal),
 	themeModalKeymap.scope((a) => a.themeModalActive && a.themeModal),
 	openRepositoryModalKeymap.scope((a) => a.openRepositoryModalActive && a.openRepositoryModal),
+	releasesModalKeymap.scope((a) => a.releasesModalActive && a.releasesModal),
 	commentModalKeymap.scope((a) => a.commentModalActive && a.commentModal),
 	deleteCommentModalKeymap.scope((a) => a.deleteCommentModalActive && a.deleteCommentModal),
 	commandPaletteKeymap.scope((a) => a.commandPaletteActive && a.commandPalette),

--- a/src/keymap/all.ts
+++ b/src/keymap/all.ts
@@ -14,6 +14,7 @@ import { listNavKeymap, type ListNavCtx } from "./listNav.ts"
 import { mergeModalKeymap, type MergeModalCtx } from "./mergeModal.ts"
 import { openRepositoryModalKeymap, type OpenRepositoryModalCtx } from "./openRepositoryModal.ts"
 import { pullRequestStateModalKeymap, type PullRequestStateModalCtx } from "./pullRequestStateModal.ts"
+import { deleteReleaseModalKeymap, type DeleteReleaseModalCtx } from "./deleteReleaseModal.ts"
 import { releaseFormKeymap, type ReleaseFormCtx } from "./releaseForm.ts"
 import { releasesModalKeymap, type ReleasesModalCtx } from "./releasesModal.ts"
 import { submitReviewModalKeymap, type SubmitReviewModalCtx } from "./submitReviewModal.ts"
@@ -32,6 +33,7 @@ export interface AppCtx {
 	readonly openRepositoryModalActive: boolean
 	readonly releasesModalActive: boolean
 	readonly releaseFormActive: boolean
+	readonly deleteReleaseModalActive: boolean
 	readonly commentModalActive: boolean
 	readonly deleteCommentModalActive: boolean
 	readonly commandPaletteActive: boolean
@@ -56,6 +58,7 @@ export interface AppCtx {
 	readonly openRepositoryModal: OpenRepositoryModalCtx
 	readonly releasesModal: ReleasesModalCtx
 	readonly releaseForm: ReleaseFormCtx
+	readonly deleteReleaseModal: DeleteReleaseModalCtx
 	readonly commentModal: CommentModalCtx
 	readonly deleteCommentModal: DeleteCommentModalCtx
 	readonly commandPalette: CommandPaletteCtx
@@ -84,6 +87,7 @@ const modalActive = (a: AppCtx): boolean =>
 	a.openRepositoryModalActive ||
 	a.releasesModalActive ||
 	a.releaseFormActive ||
+	a.deleteReleaseModalActive ||
 	a.commentModalActive ||
 	a.deleteCommentModalActive ||
 	a.commandPaletteActive
@@ -121,6 +125,7 @@ export const appKeymap = App(
 	openRepositoryModalKeymap.scope((a) => a.openRepositoryModalActive && a.openRepositoryModal),
 	releasesModalKeymap.scope((a) => a.releasesModalActive && a.releasesModal),
 	releaseFormKeymap.scope((a) => a.releaseFormActive && a.releaseForm),
+	deleteReleaseModalKeymap.scope((a) => a.deleteReleaseModalActive && a.deleteReleaseModal),
 	commentModalKeymap.scope((a) => a.commentModalActive && a.commentModal),
 	deleteCommentModalKeymap.scope((a) => a.deleteCommentModalActive && a.deleteCommentModal),
 	commandPaletteKeymap.scope((a) => a.commandPaletteActive && a.commandPalette),

--- a/src/keymap/deleteReleaseModal.ts
+++ b/src/keymap/deleteReleaseModal.ts
@@ -1,0 +1,20 @@
+import { context } from "@ghui/keymap"
+
+export interface DeleteReleaseModalCtx {
+	readonly running: boolean
+	readonly closeModal: () => void
+	readonly confirmDelete: () => void
+}
+
+const DeleteRelease = context<DeleteReleaseModalCtx>()
+
+export const deleteReleaseModalKeymap = DeleteRelease(
+	{ id: "delete-release-modal.cancel", title: "Cancel", keys: ["escape"], run: (s) => s.closeModal() },
+	{
+		id: "delete-release-modal.confirm",
+		title: "Delete release",
+		keys: ["return"],
+		enabled: (s) => (s.running ? "Already deleting." : true),
+		run: (s) => s.confirmDelete(),
+	},
+)

--- a/src/keymap/releaseForm.ts
+++ b/src/keymap/releaseForm.ts
@@ -1,0 +1,106 @@
+import { context } from "@ghui/keymap"
+
+export interface ReleaseFormCtx {
+	readonly bodyFocused: boolean
+	readonly toggleFocused: boolean
+	readonly canSubmit: boolean
+	readonly canGenerate: boolean
+	readonly nextFocus: () => void
+	readonly previousFocus: () => void
+	readonly cancel: () => void
+	readonly publish: () => void
+	readonly saveDraft: () => void
+	readonly generateNotes: () => void
+	readonly toggleField: () => void
+	readonly insertNewline: () => void
+	readonly moveLeft: () => void
+	readonly moveRight: () => void
+	readonly moveUp: () => void
+	readonly moveDown: () => void
+	readonly moveLineStart: () => void
+	readonly moveLineEnd: () => void
+	readonly moveWordBackward: () => void
+	readonly moveWordForward: () => void
+	readonly backspace: () => void
+	readonly deleteForward: () => void
+	readonly deleteWordBackward: () => void
+	readonly deleteWordForward: () => void
+	readonly deleteToLineStart: () => void
+	readonly deleteToLineEnd: () => void
+}
+
+const ReleaseForm = context<ReleaseFormCtx>()
+
+export const releaseFormKeymap = ReleaseForm(
+	{ id: "release-form.cancel", title: "Cancel", keys: ["escape"], run: (s) => s.cancel() },
+
+	// Field navigation (always available — works on every focus state).
+	{ id: "release-form.next", title: "Next field", keys: ["tab"], run: (s) => s.nextFocus() },
+	{ id: "release-form.previous", title: "Previous field", keys: ["shift+tab"], run: (s) => s.previousFocus() },
+
+	// Submit shortcuts (work everywhere).
+	{
+		id: "release-form.publish",
+		title: "Publish",
+		keys: ["ctrl+return", "shift+return"],
+		when: (s) => !s.bodyFocused,
+		enabled: (s) => (s.canSubmit ? true : "Enter a tag first."),
+		run: (s) => s.publish(),
+	},
+	{
+		id: "release-form.publish-from-body",
+		title: "Publish",
+		keys: ["ctrl+return"],
+		when: (s) => s.bodyFocused,
+		enabled: (s) => (s.canSubmit ? true : "Enter a tag first."),
+		run: (s) => s.publish(),
+	},
+	{
+		id: "release-form.save-draft",
+		title: "Save draft",
+		keys: ["ctrl+s"],
+		enabled: (s) => (s.canSubmit ? true : "Enter a tag first."),
+		run: (s) => s.saveDraft(),
+	},
+	{
+		id: "release-form.generate-notes",
+		title: "Generate notes",
+		keys: ["ctrl+g"],
+		enabled: (s) => (s.canGenerate ? true : "Enter a tag first."),
+		run: (s) => s.generateNotes(),
+	},
+
+	// Toggle space when focused on prerelease/makeLatest.
+	{
+		id: "release-form.toggle",
+		title: "Toggle",
+		keys: ["space"],
+		when: (s) => s.toggleFocused,
+		run: (s) => s.toggleField(),
+	},
+	// Enter on toggle row also advances the value.
+	{
+		id: "release-form.toggle-enter",
+		title: "Toggle",
+		keys: ["return"],
+		when: (s) => s.toggleFocused,
+		run: (s) => s.toggleField(),
+	},
+
+	// Body editing (only active when focus === "body").
+	{ id: "release-form.body-newline", title: "Newline", keys: ["return"], when: (s) => s.bodyFocused, run: (s) => s.insertNewline() },
+	{ id: "release-form.body-left", title: "Cursor left", keys: ["left", "ctrl+b"], when: (s) => s.bodyFocused, run: (s) => s.moveLeft() },
+	{ id: "release-form.body-right", title: "Cursor right", keys: ["right", "ctrl+f"], when: (s) => s.bodyFocused, run: (s) => s.moveRight() },
+	{ id: "release-form.body-up", title: "Cursor up", keys: ["up"], when: (s) => s.bodyFocused, run: (s) => s.moveUp() },
+	{ id: "release-form.body-down", title: "Cursor down", keys: ["down"], when: (s) => s.bodyFocused, run: (s) => s.moveDown() },
+	{ id: "release-form.body-line-start", title: "Line start", keys: ["home", "ctrl+a"], when: (s) => s.bodyFocused, run: (s) => s.moveLineStart() },
+	{ id: "release-form.body-line-end", title: "Line end", keys: ["end", "ctrl+e"], when: (s) => s.bodyFocused, run: (s) => s.moveLineEnd() },
+	{ id: "release-form.body-word-back", title: "Word backward", keys: ["meta+b", "meta+left"], when: (s) => s.bodyFocused, run: (s) => s.moveWordBackward() },
+	{ id: "release-form.body-word-fwd", title: "Word forward", keys: ["meta+f", "meta+right"], when: (s) => s.bodyFocused, run: (s) => s.moveWordForward() },
+	{ id: "release-form.body-backspace", title: "Backspace", keys: ["backspace"], when: (s) => s.bodyFocused, run: (s) => s.backspace() },
+	{ id: "release-form.body-delete", title: "Delete", keys: ["delete", "ctrl+d"], when: (s) => s.bodyFocused, run: (s) => s.deleteForward() },
+	{ id: "release-form.body-del-word-back", title: "Delete word back", keys: ["ctrl+w", "meta+backspace"], when: (s) => s.bodyFocused, run: (s) => s.deleteWordBackward() },
+	{ id: "release-form.body-del-word-fwd", title: "Delete word forward", keys: ["meta+delete"], when: (s) => s.bodyFocused, run: (s) => s.deleteWordForward() },
+	{ id: "release-form.body-del-to-start", title: "Delete to line start", keys: ["ctrl+u"], when: (s) => s.bodyFocused, run: (s) => s.deleteToLineStart() },
+	{ id: "release-form.body-del-to-end", title: "Delete to line end", keys: ["ctrl+k"], when: (s) => s.bodyFocused, run: (s) => s.deleteToLineEnd() },
+)

--- a/src/keymap/releasesModal.ts
+++ b/src/keymap/releasesModal.ts
@@ -18,6 +18,7 @@ export interface ReleasesModalCtx {
 	readonly loadMore: () => void
 	readonly newRelease: () => void
 	readonly editRelease: () => void
+	readonly deleteRelease: () => void
 }
 
 const Releases = context<ReleasesModalCtx>()
@@ -115,5 +116,12 @@ export const releasesModalKeymap = Releases(
 		when: (s) => s.panel === "list",
 		enabled: (s) => (s.hasSelection ? true : "No release selected."),
 		run: (s) => s.editRelease(),
+	},
+	{
+		id: "releases.delete",
+		title: "Delete release",
+		keys: ["shift+d"],
+		enabled: (s) => (s.panel === "details" || s.hasSelection ? true : "No release selected."),
+		run: (s) => s.deleteRelease(),
 	},
 )

--- a/src/keymap/releasesModal.ts
+++ b/src/keymap/releasesModal.ts
@@ -1,0 +1,102 @@
+import { context } from "@ghui/keymap"
+
+export interface ReleasesModalCtx {
+	readonly panel: "list" | "details"
+	readonly hasReleases: boolean
+	readonly hasSelection: boolean
+	readonly hasNextPage: boolean
+	readonly loadingMore: boolean
+	readonly closeOrBack: () => void
+	readonly moveSelection: (delta: -1 | 1) => void
+	readonly jumpSelection: (target: "top" | "bottom") => void
+	readonly openDetails: () => void
+	readonly scrollDetails: (delta: -1 | 1) => void
+	readonly scrollDetailsPage: (delta: -1 | 1) => void
+	readonly openInBrowser: () => void
+	readonly copyUrl: () => void
+	readonly refresh: () => void
+	readonly loadMore: () => void
+}
+
+const Releases = context<ReleasesModalCtx>()
+
+export const releasesModalKeymap = Releases(
+	{ id: "releases.close-or-back", title: "Close / back", keys: ["escape"], run: (s) => s.closeOrBack() },
+	{
+		id: "releases.up",
+		title: "Up",
+		keys: ["k", "up", "ctrl+p", "ctrl+k"],
+		run: (s) => (s.panel === "list" ? s.moveSelection(-1) : s.scrollDetails(-1)),
+	},
+	{
+		id: "releases.down",
+		title: "Down",
+		keys: ["j", "down", "ctrl+n", "ctrl+j"],
+		run: (s) => (s.panel === "list" ? s.moveSelection(1) : s.scrollDetails(1)),
+	},
+	{
+		id: "releases.page-up",
+		title: "Page up",
+		keys: ["ctrl+u", "pageup"],
+		when: (s) => s.panel === "details",
+		run: (s) => s.scrollDetailsPage(-1),
+	},
+	{
+		id: "releases.page-down",
+		title: "Page down",
+		keys: ["ctrl+d", "pagedown"],
+		when: (s) => s.panel === "details",
+		run: (s) => s.scrollDetailsPage(1),
+	},
+	{
+		id: "releases.top",
+		title: "Top",
+		keys: ["g g"],
+		when: (s) => s.panel === "list",
+		run: (s) => s.jumpSelection("top"),
+	},
+	{
+		id: "releases.bottom",
+		title: "Bottom",
+		keys: ["shift+g"],
+		when: (s) => s.panel === "list",
+		run: (s) => s.jumpSelection("bottom"),
+	},
+	{
+		id: "releases.open-details",
+		title: "View release",
+		keys: ["return"],
+		when: (s) => s.panel === "list",
+		enabled: (s) => (s.hasSelection ? true : "No release selected."),
+		run: (s) => s.openDetails(),
+	},
+	{
+		id: "releases.open-browser",
+		title: "Open in browser",
+		keys: ["o"],
+		enabled: (s) => (s.panel === "details" || s.hasSelection ? true : "No release selected."),
+		run: (s) => s.openInBrowser(),
+	},
+	{
+		id: "releases.copy-url",
+		title: "Copy URL",
+		keys: ["y"],
+		enabled: (s) => (s.panel === "details" || s.hasSelection ? true : "No release selected."),
+		run: (s) => s.copyUrl(),
+	},
+	{
+		id: "releases.refresh",
+		title: "Refresh",
+		keys: ["r"],
+		when: (s) => s.panel === "list",
+		run: (s) => s.refresh(),
+	},
+	{
+		id: "releases.load-more",
+		title: "Load more",
+		keys: ["]"],
+		when: (s) => s.panel === "list",
+		enabled: (s) => (s.loadingMore ? "Already loading more." : s.hasNextPage ? true : "No more releases."),
+		run: (s) => s.loadMore(),
+	},
+)

--- a/src/keymap/releasesModal.ts
+++ b/src/keymap/releasesModal.ts
@@ -16,6 +16,8 @@ export interface ReleasesModalCtx {
 	readonly copyUrl: () => void
 	readonly refresh: () => void
 	readonly loadMore: () => void
+	readonly newRelease: () => void
+	readonly editRelease: () => void
 }
 
 const Releases = context<ReleasesModalCtx>()
@@ -98,5 +100,20 @@ export const releasesModalKeymap = Releases(
 		when: (s) => s.panel === "list",
 		enabled: (s) => (s.loadingMore ? "Already loading more." : s.hasNextPage ? true : "No more releases."),
 		run: (s) => s.loadMore(),
+	},
+	{
+		id: "releases.new",
+		title: "New release",
+		keys: ["n"],
+		when: (s) => s.panel === "list",
+		run: (s) => s.newRelease(),
+	},
+	{
+		id: "releases.edit",
+		title: "Edit release",
+		keys: ["e"],
+		when: (s) => s.panel === "list",
+		enabled: (s) => (s.hasSelection ? true : "No release selected."),
+		run: (s) => s.editRelease(),
 	},
 )

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -3,8 +3,13 @@ import { config } from "../config.js"
 import {
 	DiffCommentSide,
 	pullRequestQueueSearchQualifier,
+	type Branch,
 	type CheckItem,
 	type CreatePullRequestCommentInput,
+	type CreateReleaseInput,
+	type DiscussionCategory,
+	type GeneratedReleaseNotes,
+	type GenerateReleaseNotesInput,
 	type ListPullRequestPageInput,
 	type Mergeable,
 	type PullRequestComment,
@@ -14,9 +19,14 @@ import {
 	type PullRequestPage,
 	type PullRequestQueueMode,
 	type PullRequestReviewComment,
+	type Release,
+	type ReleasePage,
+	type ReleaseSummary,
 	type RepositoryMergeMethods,
 	type ReviewStatus,
 	type SubmitPullRequestReviewInput,
+	type Tag,
+	type UpdateReleaseInput,
 } from "../domain.js"
 import { mergeActionCliArgs } from "../mergeActions.js"
 import { CommandError, CommandRunner, type JsonParseError } from "./CommandRunner.js"
@@ -184,6 +194,78 @@ const RepoLabelsResponseSchema = Schema.Array(
 		color: Schema.String,
 	}),
 )
+
+const ReleaseAuthorSchema = Schema.NullOr(Schema.Struct({ login: Schema.String }))
+
+const ReleaseAssetSchema = Schema.Struct({
+	id: Schema.Number,
+	name: Schema.String,
+	label: OptionalNullableString,
+	size: Schema.Number,
+	download_count: Schema.Number,
+	content_type: Schema.String,
+	browser_download_url: Schema.String,
+	url: Schema.String,
+	created_at: OptionalNullableString,
+	updated_at: OptionalNullableString,
+})
+
+const ReleaseSchema = Schema.Struct({
+	id: Schema.Number,
+	tag_name: Schema.String,
+	target_commitish: Schema.String,
+	name: NullableString,
+	body: Schema.NullOr(Schema.String).pipe(Schema.optionalKey),
+	draft: Schema.Boolean,
+	prerelease: Schema.Boolean,
+	created_at: OptionalNullableString,
+	published_at: OptionalNullableString,
+	html_url: Schema.String,
+	discussion_url: OptionalNullableString,
+	author: ReleaseAuthorSchema,
+	assets: Schema.optionalKey(Schema.Array(ReleaseAssetSchema)),
+})
+
+const ReleaseListResponseSchema = Schema.Array(ReleaseSchema)
+
+const TagSchema = Schema.Struct({
+	name: Schema.String,
+	commit: Schema.Struct({ sha: Schema.String }),
+})
+const TagListResponseSchema = Schema.Union([Schema.Array(TagSchema), Schema.Array(Schema.Array(TagSchema))])
+
+const BranchSchema = Schema.Struct({
+	name: Schema.String,
+	commit: Schema.Struct({ sha: Schema.String }),
+})
+const BranchListResponseSchema = Schema.Union([Schema.Array(BranchSchema), Schema.Array(Schema.Array(BranchSchema))])
+
+const RepositoryMetaSchema = Schema.Struct({ default_branch: Schema.String })
+
+const GenerateReleaseNotesResponseSchema = Schema.Struct({
+	name: Schema.String,
+	body: Schema.String,
+})
+
+const DiscussionCategoriesResponseSchema = Schema.Struct({
+	data: Schema.Struct({
+		repository: Schema.NullOr(
+			Schema.Struct({
+				hasDiscussionsEnabled: Schema.Boolean,
+				discussionCategories: Schema.Struct({
+					nodes: Schema.Array(
+						Schema.Struct({
+							id: Schema.String,
+							name: Schema.String,
+							slug: Schema.String,
+							emoji: OptionalNullableString,
+						}),
+					),
+				}),
+			}),
+		),
+	}),
+})
 
 type RawPullRequestSummaryNode = Schema.Schema.Type<typeof RawPullRequestSummaryNodeSchema>
 type RawPullRequestNode = Schema.Schema.Type<typeof RawPullRequestNodeSchema>
@@ -568,6 +650,37 @@ const MERGEABLE_BY_RAW: Record<string, Mergeable> = {
 
 const normalizeMergeable = (value: string): Mergeable => MERGEABLE_BY_RAW[value] ?? "unknown"
 
+const parseReleaseSummary = (raw: Schema.Schema.Type<typeof ReleaseSchema>): ReleaseSummary => ({
+	id: raw.id,
+	tagName: raw.tag_name,
+	name: raw.name,
+	isDraft: raw.draft,
+	isPrerelease: raw.prerelease,
+	targetCommitish: raw.target_commitish,
+	author: raw.author ? { login: raw.author.login } : null,
+	createdAt: normalizeDate(raw.created_at),
+	publishedAt: normalizeDate(raw.published_at),
+	htmlUrl: raw.html_url,
+})
+
+const parseRelease = (raw: Schema.Schema.Type<typeof ReleaseSchema>): Release => ({
+	...parseReleaseSummary(raw),
+	body: raw.body ?? "",
+	discussionUrl: raw.discussion_url ?? null,
+	assets: (raw.assets ?? []).map((asset) => ({
+		id: asset.id,
+		name: asset.name,
+		label: asset.label ?? null,
+		size: asset.size,
+		downloadCount: asset.download_count,
+		contentType: asset.content_type,
+		downloadUrl: asset.browser_download_url,
+		htmlUrl: asset.url,
+		createdAt: normalizeDate(asset.created_at),
+		updatedAt: normalizeDate(asset.updated_at),
+	})),
+})
+
 const REVIEW_EVENT_CLI_FLAG = {
 	COMMENT: "--comment",
 	APPROVE: "--approve",
@@ -601,6 +714,17 @@ export class GitHubService extends Context.Service<
 		readonly listRepoLabels: (repository: string) => Effect.Effect<readonly { readonly name: string; readonly color: string | null }[], GitHubError>
 		readonly addPullRequestLabel: (repository: string, number: number, label: string) => Effect.Effect<void, CommandError>
 		readonly removePullRequestLabel: (repository: string, number: number, label: string) => Effect.Effect<void, CommandError>
+		readonly listReleases: (repository: string, page: number, perPage?: number) => Effect.Effect<ReleasePage, GitHubError>
+		readonly getRelease: (repository: string, releaseId: number) => Effect.Effect<Release, GitHubError>
+		readonly getLatestRelease: (repository: string) => Effect.Effect<Release | null, GitHubError>
+		readonly listTags: (repository: string) => Effect.Effect<readonly Tag[], GitHubError>
+		readonly listBranches: (repository: string) => Effect.Effect<readonly Branch[], GitHubError>
+		readonly getDefaultBranch: (repository: string) => Effect.Effect<string, GitHubError>
+		readonly generateReleaseNotes: (repository: string, input: GenerateReleaseNotesInput) => Effect.Effect<GeneratedReleaseNotes, GitHubError>
+		readonly listDiscussionCategories: (repository: string) => Effect.Effect<readonly DiscussionCategory[], GitHubError>
+		readonly createRelease: (repository: string, input: CreateReleaseInput) => Effect.Effect<Release, GitHubError>
+		readonly updateRelease: (repository: string, releaseId: number, input: UpdateReleaseInput) => Effect.Effect<Release, GitHubError>
+		readonly deleteRelease: (repository: string, releaseId: number) => Effect.Effect<void, CommandError>
 	}
 >()("ghui/GitHubService") {
 	static readonly layerNoDeps = Layer.effect(
@@ -931,6 +1055,119 @@ export class GitHubService extends Context.Service<
 			const removePullRequestLabel = (repository: string, number: number, label: string) =>
 				ghVoid("removePullRequestLabel", ["pr", "edit", String(number), "--repo", repository, "--remove-label", label])
 
+			const listReleases = Effect.fn("GitHubService.listReleases")(function* (repository: string, page: number, perPage = 30) {
+				const safePage = Math.max(1, Math.floor(page))
+				const safePerPage = Math.max(1, Math.min(100, Math.floor(perPage)))
+				const response = yield* ghJson("listReleases", ReleaseListResponseSchema, ["api", `repos/${repository}/releases?per_page=${safePerPage}&page=${safePage}`])
+				return {
+					items: response.map(parseReleaseSummary),
+					hasNextPage: response.length === safePerPage,
+					nextPage: response.length === safePerPage ? safePage + 1 : null,
+				} satisfies ReleasePage
+			})
+
+			const getRelease = (repository: string, releaseId: number) =>
+				ghJson("getRelease", ReleaseSchema, ["api", `repos/${repository}/releases/${releaseId}`]).pipe(Effect.map(parseRelease))
+
+			const getLatestRelease = (repository: string) =>
+				ghJson("getLatestRelease", ReleaseSchema, ["api", `repos/${repository}/releases/latest`]).pipe(
+					Effect.map((value): Release | null => parseRelease(value)),
+					Effect.catchTag("CommandError", (error) => (error.detail.includes("404") ? Effect.succeed(null) : Effect.fail(error))),
+				)
+
+			const listTags = (repository: string) =>
+				ghJson("listTags", TagListResponseSchema, ["api", "--paginate", "--slurp", `repos/${repository}/tags?per_page=100`]).pipe(
+					Effect.map((response) =>
+						flattenSlurpedPages(response).map(
+							(tag): Tag => ({
+								name: tag.name,
+								commitSha: tag.commit.sha,
+							}),
+						),
+					),
+				)
+
+			const getDefaultBranch = (repository: string) =>
+				ghJson("getDefaultBranch", RepositoryMetaSchema, ["api", `repos/${repository}`]).pipe(Effect.map((meta) => meta.default_branch))
+
+			const listBranches = Effect.fn("GitHubService.listBranches")(function* (repository: string) {
+				const [response, defaultBranch] = yield* Effect.all(
+					[ghJson("listBranchesPaged", BranchListResponseSchema, ["api", "--paginate", "--slurp", `repos/${repository}/branches?per_page=100`]), getDefaultBranch(repository)],
+					{ concurrency: "unbounded" },
+				)
+				return flattenSlurpedPages(response).map(
+					(branch): Branch => ({
+						name: branch.name,
+						commitSha: branch.commit.sha,
+						isDefault: branch.name === defaultBranch,
+					}),
+				)
+			})
+
+			const generateReleaseNotes = Effect.fn("GitHubService.generateReleaseNotes")(function* (repository: string, input: GenerateReleaseNotesInput) {
+				const args = [
+					"api",
+					"--method",
+					"POST",
+					`repos/${repository}/releases/generate-notes`,
+					"-f",
+					`tag_name=${input.tagName}`,
+					...(input.previousTagName ? ["-f", `previous_tag_name=${input.previousTagName}`] : []),
+					...(input.targetCommitish ? ["-f", `target_commitish=${input.targetCommitish}`] : []),
+					...(input.configurationFilePath ? ["-f", `configuration_file_path=${input.configurationFilePath}`] : []),
+				]
+				return yield* ghJson("generateReleaseNotes", GenerateReleaseNotesResponseSchema, args)
+			})
+
+			const listDiscussionCategories = Effect.fn("GitHubService.listDiscussionCategories")(function* (repository: string) {
+				const repo = repositoryParts(repository)
+				if (!repo) {
+					return yield* new CommandError({ command: "gh", args: [], detail: `Invalid repository: ${repository}`, cause: repository })
+				}
+				const response = yield* ghJson("listDiscussionCategories", DiscussionCategoriesResponseSchema, [
+					"api",
+					"graphql",
+					"-f",
+					"query=query($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { hasDiscussionsEnabled discussionCategories(first: 50) { nodes { id name slug emoji } } } }",
+					"-F",
+					`owner=${repo.owner}`,
+					"-F",
+					`name=${repo.name}`,
+				])
+				const repoNode = response.data.repository
+				if (!repoNode || !repoNode.hasDiscussionsEnabled) return [] as readonly DiscussionCategory[]
+				return repoNode.discussionCategories.nodes.map(
+					(node): DiscussionCategory => ({
+						id: node.id,
+						name: node.name,
+						slug: node.slug,
+						emoji: node.emoji ?? null,
+					}),
+				)
+			})
+
+			const releaseBodyArgs = (input: CreateReleaseInput | UpdateReleaseInput): readonly string[] => {
+				const out: string[] = []
+				if (input.tagName !== undefined) out.push("-f", `tag_name=${input.tagName}`)
+				if (input.targetCommitish !== undefined) out.push("-f", `target_commitish=${input.targetCommitish}`)
+				if (input.name !== undefined) out.push("-f", `name=${input.name}`)
+				if (input.body !== undefined) out.push("-f", `body=${input.body}`)
+				if (input.draft !== undefined) out.push("-F", `draft=${input.draft}`)
+				if (input.prerelease !== undefined) out.push("-F", `prerelease=${input.prerelease}`)
+				if (input.makeLatest !== undefined) out.push("-f", `make_latest=${input.makeLatest}`)
+				if (input.discussionCategoryName !== undefined) out.push("-f", `discussion_category_name=${input.discussionCategoryName}`)
+				if ("generateReleaseNotes" in input && input.generateReleaseNotes !== undefined) out.push("-F", `generate_release_notes=${input.generateReleaseNotes}`)
+				return out
+			}
+
+			const createRelease = (repository: string, input: CreateReleaseInput) =>
+				ghJson("createRelease", ReleaseSchema, ["api", "--method", "POST", `repos/${repository}/releases`, ...releaseBodyArgs(input)]).pipe(Effect.map(parseRelease))
+
+			const updateRelease = (repository: string, releaseId: number, input: UpdateReleaseInput) =>
+				ghJson("updateRelease", ReleaseSchema, ["api", "--method", "PATCH", `repos/${repository}/releases/${releaseId}`, ...releaseBodyArgs(input)]).pipe(Effect.map(parseRelease))
+
+			const deleteRelease = (repository: string, releaseId: number) => ghVoid("deleteRelease", ["api", "--method", "DELETE", `repos/${repository}/releases/${releaseId}`])
+
 			return GitHubService.of({
 				listOpenPullRequests,
 				listOpenPullRequestPage,
@@ -956,6 +1193,17 @@ export class GitHubService extends Context.Service<
 				listRepoLabels,
 				addPullRequestLabel,
 				removePullRequestLabel,
+				listReleases,
+				getRelease,
+				getLatestRelease,
+				listTags,
+				listBranches,
+				getDefaultBranch,
+				generateReleaseNotes,
+				listDiscussionCategories,
+				createRelease,
+				updateRelease,
+				deleteRelease,
 			})
 		}),
 	)

--- a/src/services/MockGitHubService.ts
+++ b/src/services/MockGitHubService.ts
@@ -1,7 +1,10 @@
 import { Effect, Layer } from "effect"
 import type {
+	Branch,
 	CheckItem,
 	CreatePullRequestCommentInput,
+	CreateReleaseInput,
+	DiscussionCategory,
 	Mergeable,
 	PullRequestComment,
 	PullRequestItem,
@@ -10,7 +13,12 @@ import type {
 	PullRequestPage,
 	PullRequestQueueMode,
 	PullRequestReviewComment,
+	Release,
+	ReleasePage,
+	ReleaseSummary,
 	ReviewStatus,
+	Tag,
+	UpdateReleaseInput,
 } from "../domain.js"
 import { mergeInfoFromPullRequest } from "../mergeActions.js"
 import { GitHubService } from "./GitHubService.js"
@@ -117,9 +125,51 @@ const mockDiff = `diff --git a/src/mockDiff.ts b/src/mockDiff.ts
 +const newTwo = 2
  export const after = true`
 
+const buildMockReleases = (repos: readonly string[]): Map<string, Release[]> => {
+	const map = new Map<string, Release[]>()
+	for (const repo of repos) {
+		const releases: Release[] = Array.from({ length: 3 }, (_, index) => {
+			const version = `v0.${3 - index}.0`
+			const publishedAt = new Date(Date.now() - index * 7 * 86_400_000)
+			return {
+				id: 100 + index,
+				tagName: version,
+				name: `Release ${version}`,
+				isDraft: false,
+				isPrerelease: index === 0,
+				targetCommitish: "main",
+				author: { login: "mock-user" },
+				createdAt: publishedAt,
+				publishedAt,
+				htmlUrl: `https://github.com/${repo}/releases/tag/${version}`,
+				body: `## What's changed\n\n- Mock change ${index} A\n- Mock change ${index} B\n`,
+				discussionUrl: null,
+				assets: [],
+			} satisfies Release
+		})
+		map.set(repo, releases)
+	}
+	return map
+}
+
 export const MockGitHubService = {
 	layer: (options: MockOptions) => {
 		const items = buildMockPullRequests(options)
+		const repos = Array.from(new Set(items.map((item) => item.repository)))
+		const releasesByRepo = buildMockReleases(repos)
+		let nextReleaseId = 1000
+		const toSummary = (release: Release): ReleaseSummary => ({
+			id: release.id,
+			tagName: release.tagName,
+			name: release.name,
+			isDraft: release.isDraft,
+			isPrerelease: release.isPrerelease,
+			targetCommitish: release.targetCommitish,
+			author: release.author,
+			createdAt: release.createdAt,
+			publishedAt: release.publishedAt,
+			htmlUrl: release.htmlUrl,
+		})
 		const username = options.username ?? "mock-user"
 		const summaryItems = items.map(
 			(item) =>
@@ -276,6 +326,94 @@ export const MockGitHubService = {
 				listRepoLabels: () => Effect.succeed([]),
 				addPullRequestLabel: () => Effect.void,
 				removePullRequestLabel: () => Effect.void,
+				listReleases: (repository: string, page: number, perPage = 30) => {
+					const all = releasesByRepo.get(repository) ?? []
+					const safePage = Math.max(1, Math.floor(page))
+					const safePerPage = Math.max(1, Math.min(100, Math.floor(perPage)))
+					const start = (safePage - 1) * safePerPage
+					const slice = all.slice(start, start + safePerPage)
+					return Effect.succeed({
+						items: slice.map(toSummary),
+						hasNextPage: start + slice.length < all.length,
+						nextPage: start + slice.length < all.length ? safePage + 1 : null,
+					} satisfies ReleasePage)
+				},
+				getRelease: (repository, releaseId) => {
+					const found = (releasesByRepo.get(repository) ?? []).find((r) => r.id === releaseId)
+					return found ? Effect.succeed(found) : Effect.succeed((releasesByRepo.get(repository) ?? [])[0]!)
+				},
+				getLatestRelease: (repository) => {
+					const all = (releasesByRepo.get(repository) ?? []).filter((r) => !r.isDraft && !r.isPrerelease)
+					return Effect.succeed(all[0] ?? null)
+				},
+				listTags: (repository) => {
+					const tags: readonly Tag[] = (releasesByRepo.get(repository) ?? []).map((r) => ({ name: r.tagName, commitSha: "deadbeef" }))
+					return Effect.succeed(tags)
+				},
+				listBranches: (_repository) =>
+					Effect.succeed([
+						{ name: "main", commitSha: "deadbeef", isDefault: true },
+						{ name: "develop", commitSha: "feedface", isDefault: false },
+					] satisfies readonly Branch[]),
+				getDefaultBranch: () => Effect.succeed("main"),
+				generateReleaseNotes: (_repository, input) =>
+					Effect.succeed({
+						name: `Release ${input.tagName}`,
+						body: `## What's Changed\n\n- Mock generated notes for ${input.tagName}\n${input.previousTagName ? `\n**Full Changelog**: ${input.previousTagName}...${input.tagName}\n` : ""}`,
+					}),
+				listDiscussionCategories: () =>
+					Effect.succeed([
+						{ id: "DC_1", name: "Announcements", slug: "announcements", emoji: ":mega:" },
+						{ id: "DC_2", name: "General", slug: "general", emoji: ":speech_balloon:" },
+					] satisfies readonly DiscussionCategory[]),
+				createRelease: (repository: string, input: CreateReleaseInput) => {
+					const now = new Date()
+					const release: Release = {
+						id: nextReleaseId++,
+						tagName: input.tagName,
+						name: input.name ?? null,
+						isDraft: input.draft ?? false,
+						isPrerelease: input.prerelease ?? false,
+						targetCommitish: input.targetCommitish ?? "main",
+						author: { login: username },
+						createdAt: now,
+						publishedAt: input.draft ? null : now,
+						htmlUrl: `https://github.com/${repository}/releases/tag/${input.tagName}`,
+						body: input.body ?? "",
+						discussionUrl: input.discussionCategoryName ? `https://github.com/${repository}/discussions/1` : null,
+						assets: [],
+					}
+					const list = releasesByRepo.get(repository) ?? []
+					releasesByRepo.set(repository, [release, ...list])
+					return Effect.succeed(release)
+				},
+				updateRelease: (repository: string, releaseId: number, input: UpdateReleaseInput) => {
+					const list = releasesByRepo.get(repository) ?? []
+					const idx = list.findIndex((r) => r.id === releaseId)
+					if (idx === -1) return Effect.succeed(list[0]!)
+					const current = list[idx]!
+					const updated: Release = {
+						...current,
+						tagName: input.tagName ?? current.tagName,
+						targetCommitish: input.targetCommitish ?? current.targetCommitish,
+						name: input.name !== undefined ? input.name : current.name,
+						body: input.body !== undefined ? input.body : current.body,
+						isDraft: input.draft ?? current.isDraft,
+						isPrerelease: input.prerelease ?? current.isPrerelease,
+					}
+					const next = [...list]
+					next[idx] = updated
+					releasesByRepo.set(repository, next)
+					return Effect.succeed(updated)
+				},
+				deleteRelease: (repository, releaseId) => {
+					const list = releasesByRepo.get(repository) ?? []
+					releasesByRepo.set(
+						repository,
+						list.filter((r) => r.id !== releaseId),
+					)
+					return Effect.void
+				},
 			}),
 		)
 	},

--- a/src/ui/ReleaseForm.tsx
+++ b/src/ui/ReleaseForm.tsx
@@ -1,0 +1,251 @@
+import { TextAttributes } from "@opentui/core"
+import { type CommentEditorValue, commentEditorLines, cursorLineIndexForLines } from "./commentEditor.js"
+import { colors } from "./colors.js"
+import type { ReleaseFormFocus, ReleaseFormState } from "./modals.js"
+import { Divider, fitCell, HintRow, ModalFrame, PaddedRow, PlainLine, TextLine, type Token, TokenLine } from "./primitives.js"
+import { shortRepoName } from "./pullRequests.js"
+
+interface ReleaseFormProps {
+	readonly state: ReleaseFormState
+	readonly modalWidth: number
+	readonly modalHeight: number
+	readonly offsetLeft: number
+	readonly offsetTop: number
+	readonly loadingIndicator: string
+}
+
+const labelWidth = 13
+const bodyRowCount = 8
+
+const SingleLineRow = ({ label, value, placeholder, focused, rowWidth }: { label: string; value: string; placeholder: string; focused: boolean; rowWidth: number }) => {
+	const labelText = fitCell(label, labelWidth)
+	const fieldWidth = Math.max(8, rowWidth - labelWidth - 4)
+	const showPlaceholder = value.length === 0
+	const text = showPlaceholder ? placeholder : value
+	const cursorChar = focused ? "▏" : ""
+	const inner = `${text}${focused ? cursorChar : ""}`
+	const fieldText = fitCell(inner, fieldWidth)
+	return (
+		<TextLine width={rowWidth}>
+			<span fg={focused ? colors.accent : colors.muted}>{labelText}</span>
+			<span fg={focused ? colors.accent : colors.muted}> {focused ? "›" : " "} </span>
+			{focused ? (
+				<span fg={showPlaceholder ? colors.muted : colors.text} bg={colors.selectedBg}>
+					{fieldText}
+				</span>
+			) : (
+				<span fg={showPlaceholder ? colors.muted : colors.text}>{fieldText}</span>
+			)}
+		</TextLine>
+	)
+}
+
+const PrereleaseRow = ({ checked, focused, rowWidth }: { checked: boolean; focused: boolean; rowWidth: number }) => {
+	const labelText = fitCell("Pre-release", labelWidth)
+	const box = checked ? "[x]" : "[ ]"
+	const inner = ` ${box}  Mark as a pre-release`
+	const fieldWidth = Math.max(8, rowWidth - labelWidth - 4)
+	return (
+		<TextLine width={rowWidth}>
+			<span fg={focused ? colors.accent : colors.muted}>{labelText}</span>
+			<span fg={focused ? colors.accent : colors.muted}> {focused ? "›" : " "} </span>
+			{focused ? (
+				<span fg={colors.selectedText} bg={colors.selectedBg}>
+					{fitCell(inner, fieldWidth)}
+				</span>
+			) : (
+				<span fg={colors.text}>{fitCell(inner, fieldWidth)}</span>
+			)}
+		</TextLine>
+	)
+}
+
+const MakeLatestRow = ({ value, focused, rowWidth }: { value: ReleaseFormState["makeLatest"]; focused: boolean; rowWidth: number }) => {
+	const labelText = fitCell("Latest", labelWidth)
+	const tokens: readonly Token[] = (
+		[
+			["true", "yes"],
+			["false", "no"],
+			["legacy", "auto"],
+		] as const
+	).map(
+		([key, display]): Token =>
+			key === value
+				? focused
+					? { text: ` ${display} `, fg: colors.selectedText, bg: colors.selectedBg, bold: true }
+					: { text: ` ${display} `, fg: colors.text, bold: true }
+				: { text: ` ${display} `, fg: colors.muted },
+	)
+	return (
+		<TextLine width={rowWidth}>
+			<span fg={focused ? colors.accent : colors.muted}>{labelText}</span>
+			<span fg={focused ? colors.accent : colors.muted}> {focused ? "›" : " "} </span>
+			<TokenLine tokens={tokens} separator="" />
+		</TextLine>
+	)
+}
+
+const BodyEditor = ({ value, focused, rowWidth }: { value: CommentEditorValue; focused: boolean; rowWidth: number }) => {
+	const lines = commentEditorLines(value.body)
+	const cursorLineIndex = focused ? cursorLineIndexForLines(lines, value.cursor) : -1
+	const textWidth = Math.max(8, rowWidth - 2)
+
+	const visible = lines.slice(Math.max(0, lines.length - bodyRowCount))
+	const offset = lines.length - visible.length
+
+	const rendered: React.ReactNode[] = []
+	for (let i = 0; i < bodyRowCount; i++) {
+		const lineIndex = offset + i
+		const line = visible[i]
+		if (line === undefined) {
+			rendered.push(<PlainLine key={`body-pad-${i}`} text={fitCell("", rowWidth)} />)
+			continue
+		}
+		const isCursorLine = lineIndex === cursorLineIndex
+		const cursorRel = isCursorLine ? Math.max(0, value.cursor - line.start) : -1
+		if (!isCursorLine) {
+			rendered.push(<PlainLine key={`body-${lineIndex}`} text={fitCell(`  ${line.text}`, rowWidth)} fg={colors.text} />)
+			continue
+		}
+		const before = line.text.slice(0, cursorRel)
+		const after = line.text.slice(cursorRel)
+		const beforePad = `  ${before}`
+		const trail = fitCell(after, Math.max(0, textWidth - beforePad.length + 2 - 1))
+		rendered.push(
+			<TextLine key={`body-${lineIndex}`} width={rowWidth}>
+				<span fg={colors.text}>{beforePad}</span>
+				<span fg={colors.background} bg={colors.text}>
+					{after.length > 0 ? after.slice(0, 1) : " "}
+				</span>
+				<span fg={colors.text}>{after.slice(1) + " ".repeat(Math.max(0, trail.length - after.length + 1))}</span>
+			</TextLine>,
+		)
+	}
+	return (
+		<>
+			<TextLine width={rowWidth}>
+				<span fg={focused ? colors.accent : colors.muted}>{fitCell("Description", labelWidth)}</span>
+				<span fg={focused ? colors.accent : colors.muted}> {focused ? "›" : " "} </span>
+				<span fg={colors.muted}>{focused ? "↵ newline · arrows move · ctrl-↵ publish" : "tab to edit"}</span>
+			</TextLine>
+			{rendered}
+		</>
+	)
+}
+
+const focusOrder: readonly ReleaseFormFocus[] = ["tag", "target", "title", "body", "prerelease", "makeLatest"]
+
+export const ReleaseForm = ({ state, modalWidth, modalHeight, offsetLeft, offsetTop, loadingIndicator }: ReleaseFormProps) => {
+	const innerWidth = Math.max(20, modalWidth - 2)
+	const rowWidth = innerWidth - 2
+	const targetPlaceholder = state.target.length === 0 ? (state.defaultBranch ?? (state.defaultBranchLoading ? `${loadingIndicator} loading default branch…` : "main")) : ""
+	const titlePlaceholder = state.tag.length > 0 ? state.tag : "Release title"
+
+	// Header
+	const repoText = shortRepoName(state.repository)
+	const modeText = state.mode === "edit" ? "Edit release" : "New release"
+	const subtitleText = `${repoText}${state.originalTagName ? ` · ${state.originalTagName}` : ""}`
+	const headerRightText = state.submitting ? `${loadingIndicator} submitting…` : state.generatingNotes ? `${loadingIndicator} generating…` : ""
+
+	const focusIndex = focusOrder.indexOf(state.focus)
+
+	// Junction rows: title row 0, blank 1, divider 2, body header 3, body lines 4..(3+bodyRowCount), divider, prerelease, makeLatest, divider, footer.
+	// Layout (heights):
+	//   row 0 title bar
+	//   row 1 subtitle
+	//   row 2 divider
+	//   row 3 tag
+	//   row 4 target
+	//   row 5 title
+	//   row 6 divider
+	//   row 7 body header
+	//   rows 8..(7+bodyRowCount) body
+	//   row 8+bodyRowCount divider
+	//   row 9+bodyRowCount prerelease
+	//   row 10+bodyRowCount makeLatest
+	//   row 11+bodyRowCount divider
+	//   row 12+bodyRowCount error / status
+	//   row 13+bodyRowCount divider
+	//   row 14+bodyRowCount footer
+	const junctionRows = [2, 6, 8 + bodyRowCount, 11 + bodyRowCount, 13 + bodyRowCount]
+	void focusIndex
+
+	return (
+		<ModalFrame left={offsetLeft} top={offsetTop} width={modalWidth} height={modalHeight} junctionRows={junctionRows}>
+			<PaddedRow>
+				<TextLine>
+					<span fg={colors.accent} attributes={TextAttributes.BOLD}>
+						{modeText}
+					</span>
+					{headerRightText.length > 0 ? (
+						<>
+							<span> </span>
+							<span fg={colors.status.pending}>{headerRightText}</span>
+						</>
+					) : null}
+				</TextLine>
+			</PaddedRow>
+			<PaddedRow>
+				<TextLine>
+					<span fg={colors.muted}>{fitCell(subtitleText, rowWidth)}</span>
+				</TextLine>
+			</PaddedRow>
+			<Divider width={innerWidth} />
+
+			<PaddedRow>
+				<SingleLineRow label="Tag" value={state.tag} placeholder="v1.2.3" focused={state.focus === "tag"} rowWidth={rowWidth} />
+			</PaddedRow>
+			<PaddedRow>
+				<SingleLineRow label="Target" value={state.target} placeholder={targetPlaceholder} focused={state.focus === "target"} rowWidth={rowWidth} />
+			</PaddedRow>
+			<PaddedRow>
+				<SingleLineRow label="Title" value={state.title} placeholder={titlePlaceholder} focused={state.focus === "title"} rowWidth={rowWidth} />
+			</PaddedRow>
+
+			<Divider width={innerWidth} />
+
+			<PaddedRow>
+				<BodyEditor value={state.body} focused={state.focus === "body"} rowWidth={rowWidth} />
+			</PaddedRow>
+
+			<Divider width={innerWidth} />
+
+			<PaddedRow>
+				<PrereleaseRow checked={state.isPrerelease} focused={state.focus === "prerelease"} rowWidth={rowWidth} />
+			</PaddedRow>
+			<PaddedRow>
+				<MakeLatestRow value={state.makeLatest} focused={state.focus === "makeLatest"} rowWidth={rowWidth} />
+			</PaddedRow>
+
+			<Divider width={innerWidth} />
+
+			<PaddedRow>
+				<TextLine>
+					{state.error ? (
+						<span fg={colors.error}>{fitCell(state.error, rowWidth)}</span>
+					) : (
+						<span fg={colors.muted}>
+							{fitCell(state.mode === "edit" ? "Editing existing release. Tag changes update the release tag." : "Tab between fields. Tag is required.", rowWidth)}
+						</span>
+					)}
+				</TextLine>
+			</PaddedRow>
+
+			<Divider width={innerWidth} />
+
+			<PaddedRow>
+				<HintRow
+					items={[
+						{ key: "tab", label: "next" },
+						{ key: "ctrl-g", label: "notes" },
+						{ key: "ctrl-s", label: "draft" },
+						{ key: "ctrl-↵", label: state.mode === "edit" ? "save" : "publish" },
+						{ key: "esc", label: "cancel" },
+					]}
+				/>
+			</PaddedRow>
+		</ModalFrame>
+	)
+}
+
+export const releaseFormBodyRowCount = bodyRowCount

--- a/src/ui/ReleaseForm.tsx
+++ b/src/ui/ReleaseForm.tsx
@@ -2,7 +2,7 @@ import { TextAttributes } from "@opentui/core"
 import { type CommentEditorValue, commentEditorLines, cursorLineIndexForLines } from "./commentEditor.js"
 import { colors } from "./colors.js"
 import type { ReleaseFormFocus, ReleaseFormState } from "./modals.js"
-import { Divider, fitCell, HintRow, ModalFrame, PaddedRow, PlainLine, TextLine, type Token, TokenLine } from "./primitives.js"
+import { Divider, fitCell, HintRow, ModalFrame, PaddedRow, PlainLine, TextLine } from "./primitives.js"
 import { shortRepoName } from "./pullRequests.js"
 
 interface ReleaseFormProps {
@@ -62,25 +62,38 @@ const PrereleaseRow = ({ checked, focused, rowWidth }: { checked: boolean; focus
 
 const MakeLatestRow = ({ value, focused, rowWidth }: { value: ReleaseFormState["makeLatest"]; focused: boolean; rowWidth: number }) => {
 	const labelText = fitCell("Latest", labelWidth)
-	const tokens: readonly Token[] = (
-		[
-			["true", "yes"],
-			["false", "no"],
-			["legacy", "auto"],
-		] as const
-	).map(
-		([key, display]): Token =>
-			key === value
-				? focused
-					? { text: ` ${display} `, fg: colors.selectedText, bg: colors.selectedBg, bold: true }
-					: { text: ` ${display} `, fg: colors.text, bold: true }
-				: { text: ` ${display} `, fg: colors.muted },
-	)
+	const options = [
+		["true", "yes"],
+		["false", "no"],
+		["legacy", "auto"],
+	] as const
 	return (
 		<TextLine width={rowWidth}>
 			<span fg={focused ? colors.accent : colors.muted}>{labelText}</span>
 			<span fg={focused ? colors.accent : colors.muted}> {focused ? "›" : " "} </span>
-			<TokenLine tokens={tokens} separator="" />
+			{options.map(([key, display]) => {
+				const selected = key === value
+				const text = ` ${display} `
+				if (selected && focused) {
+					return (
+						<span key={key} fg={colors.selectedText} bg={colors.selectedBg} attributes={TextAttributes.BOLD}>
+							{text}
+						</span>
+					)
+				}
+				if (selected) {
+					return (
+						<span key={key} fg={colors.text} attributes={TextAttributes.BOLD}>
+							{text}
+						</span>
+					)
+				}
+				return (
+					<span key={key} fg={colors.muted}>
+						{text}
+					</span>
+				)
+			})}
 		</TextLine>
 	)
 }

--- a/src/ui/ReleaseForm.tsx
+++ b/src/ui/ReleaseForm.tsx
@@ -157,7 +157,10 @@ export const ReleaseForm = ({ state, modalWidth, modalHeight, offsetLeft, offset
 	// Header
 	const repoText = shortRepoName(state.repository)
 	const modeText = state.mode === "edit" ? "Edit release" : "New release"
-	const subtitleText = `${repoText}${state.originalTagName ? ` · ${state.originalTagName}` : ""}`
+	const subtitleText =
+		state.mode === "edit"
+			? `${repoText}${state.originalTagName ? ` · ${state.originalTagName}` : ""}`
+			: `${repoText}${state.latestTagName ? ` · previous: ${state.latestTagName}` : ""}`
 	const headerRightText = state.submitting ? `${loadingIndicator} submitting…` : state.generatingNotes ? `${loadingIndicator} generating…` : ""
 
 	const focusIndex = focusOrder.indexOf(state.focus)

--- a/src/ui/ReleasesModal.tsx
+++ b/src/ui/ReleasesModal.tsx
@@ -1,0 +1,315 @@
+import { TextAttributes } from "@opentui/core"
+import type { ReleaseAsset, ReleaseSummary } from "../domain.js"
+import { formatShortDate } from "../date.js"
+import { colors } from "./colors.js"
+import type { ReleasesModalState } from "./modals.js"
+import { centerCell, fitCell, Filler, HintRow, PlainLine, StandardModal, TextLine, type Token, TokenLine } from "./primitives.js"
+import { shortRepoName } from "./pullRequests.js"
+
+interface ReleasesModalProps {
+	readonly state: ReleasesModalState
+	readonly modalWidth: number
+	readonly modalHeight: number
+	readonly offsetLeft: number
+	readonly offsetTop: number
+	readonly loadingIndicator: string
+}
+
+const formatReleaseDate = (value: Date | null): string => (value ? formatShortDate(value) : "—")
+
+const releaseStatusTokens = (release: ReleaseSummary, isLatest: boolean): readonly Token[] => {
+	const tokens: Token[] = []
+	if (release.isDraft) tokens.push({ text: "draft", fg: colors.muted })
+	if (release.isPrerelease) tokens.push({ text: "pre-release", fg: colors.status.pending })
+	if (isLatest) tokens.push({ text: "latest", fg: colors.status.approved })
+	return tokens
+}
+
+const wrapBody = (body: string, width: number): readonly string[] => {
+	const safeWidth = Math.max(1, width)
+	const lines: string[] = []
+	for (const rawLine of body.split(/\r?\n/)) {
+		if (rawLine.length === 0) {
+			lines.push("")
+			continue
+		}
+		let remaining = rawLine
+		while (remaining.length > safeWidth) {
+			// Prefer breaking on a space within the last 16 chars.
+			const slice = remaining.slice(0, safeWidth)
+			const breakAt = slice.lastIndexOf(" ", safeWidth - 1)
+			const cutoff = breakAt > safeWidth - 16 ? breakAt : safeWidth
+			lines.push(remaining.slice(0, cutoff).trimEnd())
+			remaining = remaining.slice(cutoff).trimStart()
+		}
+		lines.push(remaining)
+	}
+	return lines
+}
+
+const formatBytes = (bytes: number): string => {
+	if (bytes < 1024) return `${bytes} B`
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+	if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+	return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
+}
+
+const ReleaseListRow = ({ release, isSelected, isLatest, rowWidth }: { release: ReleaseSummary; isSelected: boolean; isLatest: boolean; rowWidth: number }) => {
+	const dateText = formatReleaseDate(release.publishedAt ?? release.createdAt)
+	const author = release.author?.login ?? ""
+	const right = `${author ? `@${author}  ` : ""}${dateText}`
+	const tokens = releaseStatusTokens(release, isLatest)
+	const tagText = release.tagName
+	const nameText = release.name && release.name !== release.tagName ? release.name : ""
+	const badgesText = tokens.map((t) => t.text).join("  ")
+
+	const tagWidth = Math.min(20, Math.max(8, tagText.length))
+	const rightWidth = Math.min(28, right.length + 1)
+	const badgesWidth = badgesText.length === 0 ? 0 : Math.min(24, badgesText.length + 2)
+	const nameWidth = Math.max(1, rowWidth - tagWidth - rightWidth - badgesWidth - 1)
+
+	return (
+		<TextLine width={rowWidth} bg={isSelected ? colors.selectedBg : undefined} fg={isSelected ? colors.selectedText : colors.text}>
+			<span fg={isSelected ? colors.selectedText : colors.accent}>{fitCell(tagText, tagWidth)}</span>
+			<span> </span>
+			<span fg={isSelected ? colors.selectedText : colors.muted}>{fitCell(nameText, nameWidth)}</span>
+			{tokens.length > 0 ? (
+				<>
+					<span> </span>
+					{tokens.map((token, idx) => (
+						<span key={idx} fg={isSelected ? colors.selectedText : token.fg}>
+							{fitCell(token.text, token.text.length + (idx === tokens.length - 1 ? 0 : 2))}
+						</span>
+					))}
+				</>
+			) : null}
+			<span fg={isSelected ? colors.selectedText : colors.muted}>{fitCell(right, rightWidth, "right")}</span>
+		</TextLine>
+	)
+}
+
+const ReleasesListBody = ({ state, rowWidth, bodyHeight, loadingIndicator }: { state: ReleasesModalState; rowWidth: number; bodyHeight: number; loadingIndicator: string }) => {
+	const messageTopRows = Math.max(0, Math.floor((bodyHeight - 1) / 2))
+	const messageBottomRows = Math.max(0, bodyHeight - messageTopRows - 1)
+
+	if (state.loading && state.releases.length === 0) {
+		return (
+			<>
+				<Filler rows={messageTopRows} prefix="releases-top" />
+				<PlainLine text={centerCell(`${loadingIndicator} Loading releases…`, rowWidth)} fg={colors.muted} />
+				<Filler rows={messageBottomRows} prefix="releases-bottom" />
+			</>
+		)
+	}
+
+	if (state.error && state.releases.length === 0) {
+		return (
+			<>
+				<Filler rows={messageTopRows} prefix="releases-top" />
+				<PlainLine text={centerCell(state.error, rowWidth)} fg={colors.error} />
+				<Filler rows={messageBottomRows} prefix="releases-bottom" />
+			</>
+		)
+	}
+
+	if (state.releases.length === 0) {
+		return (
+			<>
+				<Filler rows={messageTopRows} prefix="releases-top" />
+				<PlainLine text={centerCell("No releases yet", rowWidth)} fg={colors.muted} />
+				<Filler rows={messageBottomRows} prefix="releases-bottom" />
+			</>
+		)
+	}
+
+	const reserveLoadMore = state.loadingMore || state.hasNextPage ? 1 : 0
+	const visibleRows = Math.max(1, bodyHeight - reserveLoadMore)
+	const selectedIndex = Math.max(0, Math.min(state.listSelectedIndex, state.releases.length - 1))
+	const scrollStart = Math.min(Math.max(0, state.releases.length - visibleRows), Math.max(0, selectedIndex - visibleRows + 1))
+	const visible = state.releases.slice(scrollStart, scrollStart + visibleRows)
+
+	return (
+		<>
+			{visible.map((release, idx) => {
+				const actualIndex = scrollStart + idx
+				return <ReleaseListRow key={release.id} release={release} rowWidth={rowWidth} isSelected={actualIndex === selectedIndex} isLatest={state.latestReleaseId === release.id} />
+			})}
+			{visible.length < visibleRows ? <Filler rows={visibleRows - visible.length} prefix="releases-pad" /> : null}
+			{reserveLoadMore ? (
+				<PlainLine
+					text={centerCell(state.loadingMore ? `${loadingIndicator} Loading more…` : `↓ ${state.releases.length} loaded — press ] for more`, rowWidth)}
+					fg={colors.muted}
+				/>
+			) : null}
+		</>
+	)
+}
+
+const AssetRow = ({ asset, rowWidth }: { asset: ReleaseAsset; rowWidth: number }) => {
+	const right = `${formatBytes(asset.size)}  ${asset.downloadCount}↓`
+	const rightWidth = Math.min(20, right.length + 1)
+	const nameWidth = Math.max(1, rowWidth - rightWidth - 1)
+	return (
+		<TextLine width={rowWidth} fg={colors.text}>
+			<span fg={colors.muted}>·</span>
+			<span> </span>
+			<span fg={colors.text}>{fitCell(asset.name, nameWidth)}</span>
+			<span fg={colors.muted}>{fitCell(right, rightWidth, "right")}</span>
+		</TextLine>
+	)
+}
+
+const ReleaseDetailsBody = ({ state, rowWidth, bodyHeight, loadingIndicator }: { state: ReleasesModalState; rowWidth: number; bodyHeight: number; loadingIndicator: string }) => {
+	const messageTopRows = Math.max(0, Math.floor((bodyHeight - 1) / 2))
+	const messageBottomRows = Math.max(0, bodyHeight - messageTopRows - 1)
+
+	if (state.detailsLoading && !state.detailsRelease) {
+		return (
+			<>
+				<Filler rows={messageTopRows} prefix="rel-detail-top" />
+				<PlainLine text={centerCell(`${loadingIndicator} Loading release…`, rowWidth)} fg={colors.muted} />
+				<Filler rows={messageBottomRows} prefix="rel-detail-bottom" />
+			</>
+		)
+	}
+
+	if (state.detailsError && !state.detailsRelease) {
+		return (
+			<>
+				<Filler rows={messageTopRows} prefix="rel-detail-top" />
+				<PlainLine text={centerCell(state.detailsError, rowWidth)} fg={colors.error} />
+				<Filler rows={messageBottomRows} prefix="rel-detail-bottom" />
+			</>
+		)
+	}
+
+	const release = state.detailsRelease
+	if (!release) {
+		return (
+			<>
+				<Filler rows={messageTopRows} prefix="rel-detail-top" />
+				<PlainLine text={centerCell("No release selected", rowWidth)} fg={colors.muted} />
+				<Filler rows={messageBottomRows} prefix="rel-detail-bottom" />
+			</>
+		)
+	}
+
+	// Build the body: header lines + body wrapped + asset list.
+	const isLatest = state.latestReleaseId === release.id
+	const tokens = releaseStatusTokens(release, isLatest)
+
+	const headerLines: React.ReactNode[] = []
+	headerLines.push(
+		<TextLine key="title" width={rowWidth}>
+			<span fg={colors.accent} attributes={TextAttributes.BOLD}>
+				{fitCell(release.name && release.name.length > 0 ? release.name : release.tagName, rowWidth)}
+			</span>
+		</TextLine>,
+	)
+	headerLines.push(
+		<TextLine key="meta" width={rowWidth}>
+			<span
+				fg={colors.muted}
+			>{`${release.tagName}  ·  ${formatReleaseDate(release.publishedAt ?? release.createdAt)}${release.author ? `  ·  @${release.author.login}` : ""}  ·  → ${release.targetCommitish}`}</span>
+		</TextLine>,
+	)
+	if (tokens.length > 0) {
+		headerLines.push(
+			<TextLine key="badges" width={rowWidth}>
+				<TokenLine tokens={tokens} />
+			</TextLine>,
+		)
+	}
+	headerLines.push(<PlainLine key="spacer" text="" />)
+
+	const wrapped = wrapBody(release.body || "_(no description)_", rowWidth)
+	const bodyAvailable = Math.max(1, bodyHeight - headerLines.length - (release.assets.length > 0 ? release.assets.length + 2 : 0))
+	const totalLines = wrapped.length
+	const maxScroll = Math.max(0, totalLines - bodyAvailable)
+	const scrollOffset = Math.max(0, Math.min(state.detailsScrollOffset, maxScroll))
+	const visibleBody = wrapped.slice(scrollOffset, scrollOffset + bodyAvailable)
+
+	const bodyLines = visibleBody.map((line, idx) => <PlainLine key={`body-${idx}`} text={fitCell(line, rowWidth)} fg={colors.text} />)
+	const padBody = bodyAvailable - visibleBody.length
+	if (padBody > 0) {
+		bodyLines.push(<Filler key="body-pad" rows={padBody} prefix="rel-body-pad" />)
+	}
+
+	const assetLines: React.ReactNode[] =
+		release.assets.length > 0
+			? [
+					<PlainLine key="assets-head" text={fitCell(`Assets (${release.assets.length})`, rowWidth)} fg={colors.muted} bold />,
+					...release.assets.map((asset) => <AssetRow key={asset.id} asset={asset} rowWidth={rowWidth} />),
+					<PlainLine key="assets-spacer" text="" />,
+				]
+			: []
+
+	return (
+		<>
+			{headerLines}
+			{bodyLines}
+			{assetLines}
+		</>
+	)
+}
+
+export const ReleasesModal = ({ state, modalWidth, modalHeight, offsetLeft, offsetTop, loadingIndicator }: ReleasesModalProps) => {
+	const innerWidth = Math.max(16, modalWidth - 2)
+	const contentWidth = Math.max(14, innerWidth - 2)
+	const bodyHeight = Math.max(2, modalHeight - 6)
+	const rowWidth = innerWidth
+
+	const repoText = state.repository ? shortRepoName(state.repository) : "no repository"
+	const subtitleText =
+		state.panel === "list"
+			? `${repoText}  ·  ${state.releases.length} release${state.releases.length === 1 ? "" : "s"}${state.hasNextPage ? "+" : ""}`
+			: state.detailsRelease
+				? `${repoText}  ·  ${state.detailsRelease.tagName}`
+				: repoText
+
+	const showSpinner = (state.panel === "list" && state.loading) || (state.panel === "details" && state.detailsLoading)
+
+	return (
+		<StandardModal
+			left={offsetLeft}
+			top={offsetTop}
+			width={modalWidth}
+			height={modalHeight}
+			title={state.panel === "list" ? "Releases" : "Release"}
+			{...(showSpinner ? { headerRight: { text: loadingIndicator, pending: true } } : {})}
+			subtitle={
+				<TextLine>
+					<span fg={colors.muted}>{fitCell(subtitleText, contentWidth)}</span>
+				</TextLine>
+			}
+			footer={
+				<HintRow
+					items={
+						state.panel === "list"
+							? [
+									{ key: "↑↓", label: "move" },
+									{ key: "enter", label: "view" },
+									{ key: "o", label: "browser" },
+									{ key: "y", label: "copy url" },
+									{ key: "]", label: "more" },
+									{ key: "r", label: "refresh" },
+									{ key: "esc", label: "close" },
+								]
+							: [
+									{ key: "↑↓", label: "scroll" },
+									{ key: "o", label: "browser" },
+									{ key: "y", label: "copy url" },
+									{ key: "esc", label: "back" },
+								]
+					}
+				/>
+			}
+		>
+			{state.panel === "list" ? (
+				<ReleasesListBody state={state} rowWidth={rowWidth} bodyHeight={bodyHeight} loadingIndicator={loadingIndicator} />
+			) : (
+				<ReleaseDetailsBody state={state} rowWidth={rowWidth} bodyHeight={bodyHeight} loadingIndicator={loadingIndicator} />
+			)}
+		</StandardModal>
+	)
+}

--- a/src/ui/ReleasesModal.tsx
+++ b/src/ui/ReleasesModal.tsx
@@ -3,7 +3,7 @@ import type { ReleaseAsset, ReleaseSummary } from "../domain.js"
 import { formatShortDate } from "../date.js"
 import { colors } from "./colors.js"
 import type { ReleasesModalState } from "./modals.js"
-import { centerCell, fitCell, Filler, HintRow, PlainLine, StandardModal, TextLine, type Token, TokenLine } from "./primitives.js"
+import { centerCell, fitCell, Filler, HintRow, PlainLine, StandardModal, TextLine, type Token } from "./primitives.js"
 import { shortRepoName } from "./pullRequests.js"
 
 interface ReleasesModalProps {
@@ -216,7 +216,12 @@ const ReleaseDetailsBody = ({ state, rowWidth, bodyHeight, loadingIndicator }: {
 	if (tokens.length > 0) {
 		headerLines.push(
 			<TextLine key="badges" width={rowWidth}>
-				<TokenLine tokens={tokens} />
+				{tokens.flatMap((token, idx) => [
+					<span key={`tok-${idx}`} fg={token.fg}>
+						{token.text}
+					</span>,
+					...(idx < tokens.length - 1 ? [<span key={`sep-${idx}`}>{"  "}</span>] : []),
+				])}
 			</TextLine>,
 		)
 	}

--- a/src/ui/modals.tsx
+++ b/src/ui/modals.tsx
@@ -461,6 +461,26 @@ export interface ReleaseFormState {
 	readonly error: string | null
 }
 
+export interface DeleteReleaseModalState {
+	readonly repository: string | null
+	readonly releaseId: number | null
+	readonly tagName: string
+	readonly name: string | null
+	readonly isDraft: boolean
+	readonly running: boolean
+	readonly error: string | null
+}
+
+export const initialDeleteReleaseModalState: DeleteReleaseModalState = {
+	repository: null,
+	releaseId: null,
+	tagName: "",
+	name: null,
+	isDraft: false,
+	running: false,
+	error: null,
+}
+
 export const initialReleaseFormState: ReleaseFormState = {
 	mode: "create",
 	repository: "",
@@ -503,6 +523,7 @@ export type Modal = Data.TaggedEnum<{
 	Label: LabelModalState
 	Close: CloseModalState
 	ReleaseForm: ReleaseFormState
+	DeleteRelease: DeleteReleaseModalState
 	PullRequestState: PullRequestStateModalState
 	Merge: MergeModalState
 	Comment: CommentModalState
@@ -537,6 +558,7 @@ export const modalInitialStates = {
 	OpenRepository: initialOpenRepositoryModalState,
 	Releases: initialReleasesModalState,
 	ReleaseForm: initialReleaseFormState,
+	DeleteRelease: initialDeleteReleaseModalState,
 } as const satisfies { [Tag in Exclude<ModalTag, "None">]: ModalState<Tag> }
 
 export const OpenRepositoryModal = ({
@@ -1119,6 +1141,64 @@ export const CommentModal = ({
 		>
 			{state.error ? <PlainLine text={fitCell(state.error, contentWidth)} fg={colors.error} /> : null}
 			{visibleLines.map(renderEditorLine)}
+		</StandardModal>
+	)
+}
+
+export const DeleteReleaseModal = ({
+	state,
+	modalWidth,
+	modalHeight,
+	offsetLeft,
+	offsetTop,
+	loadingIndicator,
+}: {
+	state: DeleteReleaseModalState
+	modalWidth: number
+	modalHeight: number
+	offsetLeft: number
+	offsetTop: number
+	loadingIndicator: string
+}) => {
+	const { contentWidth, bodyHeight } = standardModalDims(modalWidth, modalHeight)
+	const title = state.isDraft ? "Delete draft release" : "Delete release"
+	const rightText = state.running ? `${loadingIndicator} deleting` : "confirm"
+	const nameLine = state.name && state.name.length > 0 ? state.name : state.tagName
+	const titleLines = [fitCell(state.tagName, contentWidth), fitCell(nameLine, contentWidth)]
+	const topRows = Math.max(0, Math.floor((bodyHeight - titleLines.length - 2) / 2))
+	const bottomRows = Math.max(0, bodyHeight - topRows - titleLines.length - 2)
+	const caution = state.isDraft ? "Discards this draft. The tag is unaffected." : "Removes the release on GitHub. The underlying git tag is kept."
+
+	return (
+		<StandardModal
+			left={offsetLeft}
+			top={offsetTop}
+			width={modalWidth}
+			height={modalHeight}
+			title={title}
+			titleFg={colors.error}
+			headerRight={{ text: rightText, pending: state.running }}
+			subtitle={<PlainLine text={fitCell(caution, contentWidth)} fg={colors.muted} />}
+			bodyPadding={1}
+			footer={
+				<HintRow
+					items={[
+						{ key: "enter", label: "delete" },
+						{ key: "esc", label: "cancel" },
+					]}
+				/>
+			}
+		>
+			{state.error ? (
+				<PlainLine text={fitCell(state.error, contentWidth)} fg={colors.error} />
+			) : (
+				<>
+					<Filler rows={topRows} prefix="top" />
+					<PlainLine text={titleLines[0]!} fg={colors.accent} />
+					<PlainLine text={titleLines[1]!} fg={colors.text} />
+					<Filler rows={bottomRows} prefix="bottom" />
+				</>
+			)}
 		</StandardModal>
 	)
 }

--- a/src/ui/modals.tsx
+++ b/src/ui/modals.tsx
@@ -456,6 +456,7 @@ export interface ReleaseFormState {
 	readonly focus: ReleaseFormFocus
 	readonly defaultBranch: string | null
 	readonly defaultBranchLoading: boolean
+	readonly latestTagName: string | null
 	readonly submitting: boolean
 	readonly generatingNotes: boolean
 	readonly error: string | null
@@ -495,6 +496,7 @@ export const initialReleaseFormState: ReleaseFormState = {
 	focus: "tag",
 	defaultBranch: null,
 	defaultBranchLoading: false,
+	latestTagName: null,
 	submitting: false,
 	generatingNotes: false,
 	error: null,

--- a/src/ui/modals.tsx
+++ b/src/ui/modals.tsx
@@ -7,6 +7,8 @@ import type {
 	PullRequestMergeMethod,
 	PullRequestReviewComment,
 	PullRequestReviewEvent,
+	Release,
+	ReleaseSummary,
 	RepositoryMergeMethods,
 } from "../domain.js"
 import { allowedMergeMethodList } from "../domain.js"
@@ -415,6 +417,44 @@ export const initialOpenRepositoryModalState: OpenRepositoryModalState = {
 	error: null,
 }
 
+export type ReleasesPanel = "list" | "details"
+
+export interface ReleasesModalState {
+	readonly repository: string | null
+	readonly panel: ReleasesPanel
+	readonly releases: readonly ReleaseSummary[]
+	readonly loading: boolean
+	readonly loadingMore: boolean
+	readonly error: string | null
+	readonly hasNextPage: boolean
+	readonly nextPage: number | null
+	readonly listSelectedIndex: number
+	readonly detailsReleaseId: number | null
+	readonly detailsRelease: Release | null
+	readonly detailsLoading: boolean
+	readonly detailsError: string | null
+	readonly detailsScrollOffset: number
+	readonly latestReleaseId: number | null
+}
+
+export const initialReleasesModalState: ReleasesModalState = {
+	repository: null,
+	panel: "list",
+	releases: [],
+	loading: false,
+	loadingMore: false,
+	error: null,
+	hasNextPage: false,
+	nextPage: null,
+	listSelectedIndex: 0,
+	detailsReleaseId: null,
+	detailsRelease: null,
+	detailsLoading: false,
+	detailsError: null,
+	detailsScrollOffset: 0,
+	latestReleaseId: null,
+}
+
 export type Modal = Data.TaggedEnum<{
 	None: {}
 	Label: LabelModalState
@@ -429,6 +469,7 @@ export type Modal = Data.TaggedEnum<{
 	Theme: ThemeModalState
 	CommandPalette: CommandPaletteState
 	OpenRepository: OpenRepositoryModalState
+	Releases: ReleasesModalState
 }>
 
 export const Modal = Data.taggedEnum<Modal>()
@@ -450,6 +491,7 @@ export const modalInitialStates = {
 	Theme: initialThemeModalState,
 	CommandPalette: initialCommandPaletteState,
 	OpenRepository: initialOpenRepositoryModalState,
+	Releases: initialReleasesModalState,
 } as const satisfies { [Tag in Exclude<ModalTag, "None">]: ModalState<Tag> }
 
 export const OpenRepositoryModal = ({

--- a/src/ui/modals.tsx
+++ b/src/ui/modals.tsx
@@ -1,6 +1,7 @@
 import { TextAttributes } from "@opentui/core"
 import { Data } from "effect"
 import type {
+	MakeLatest,
 	PullRequestLabel,
 	PullRequestMergeInfo,
 	PullRequestMergeKind,
@@ -11,6 +12,7 @@ import type {
 	ReleaseSummary,
 	RepositoryMergeMethods,
 } from "../domain.js"
+import type { CommentEditorValue } from "./commentEditor.js"
 import { allowedMergeMethodList } from "../domain.js"
 import { getMergeKindDefinition, mergeKindRowTitle, visibleMergeKinds } from "../mergeActions.js"
 import { clampCursor, commentEditorLines, cursorLineIndexForLines } from "./commentEditor.js"
@@ -437,6 +439,47 @@ export interface ReleasesModalState {
 	readonly latestReleaseId: number | null
 }
 
+export const releaseFormFocuses = ["tag", "target", "title", "body", "prerelease", "makeLatest"] as const
+export type ReleaseFormFocus = (typeof releaseFormFocuses)[number]
+
+export interface ReleaseFormState {
+	readonly mode: "create" | "edit"
+	readonly repository: string
+	readonly editingReleaseId: number | null
+	readonly originalTagName: string | null
+	readonly tag: string
+	readonly target: string
+	readonly title: string
+	readonly body: CommentEditorValue
+	readonly isPrerelease: boolean
+	readonly makeLatest: MakeLatest
+	readonly focus: ReleaseFormFocus
+	readonly defaultBranch: string | null
+	readonly defaultBranchLoading: boolean
+	readonly submitting: boolean
+	readonly generatingNotes: boolean
+	readonly error: string | null
+}
+
+export const initialReleaseFormState: ReleaseFormState = {
+	mode: "create",
+	repository: "",
+	editingReleaseId: null,
+	originalTagName: null,
+	tag: "",
+	target: "",
+	title: "",
+	body: { body: "", cursor: 0 },
+	isPrerelease: false,
+	makeLatest: "true",
+	focus: "tag",
+	defaultBranch: null,
+	defaultBranchLoading: false,
+	submitting: false,
+	generatingNotes: false,
+	error: null,
+}
+
 export const initialReleasesModalState: ReleasesModalState = {
 	repository: null,
 	panel: "list",
@@ -459,6 +502,7 @@ export type Modal = Data.TaggedEnum<{
 	None: {}
 	Label: LabelModalState
 	Close: CloseModalState
+	ReleaseForm: ReleaseFormState
 	PullRequestState: PullRequestStateModalState
 	Merge: MergeModalState
 	Comment: CommentModalState
@@ -492,6 +536,7 @@ export const modalInitialStates = {
 	CommandPalette: initialCommandPaletteState,
 	OpenRepository: initialOpenRepositoryModalState,
 	Releases: initialReleasesModalState,
+	ReleaseForm: initialReleaseFormState,
 } as const satisfies { [Tag in Exclude<ModalTag, "None">]: ModalState<Tag> }
 
 export const OpenRepositoryModal = ({

--- a/test/githubServiceReleases.test.ts
+++ b/test/githubServiceReleases.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, test } from "bun:test"
+import { Effect, Layer, Schema } from "effect"
+import { CommandRunner, type CommandResult } from "../src/services/CommandRunner.ts"
+import { GitHubService } from "../src/services/GitHubService.ts"
+
+interface RecordedCall {
+	readonly command: string
+	readonly args: readonly string[]
+}
+
+const fakeCommandRunner = (response: string, recorder: RecordedCall[]) =>
+	Layer.succeed(
+		CommandRunner,
+		CommandRunner.of({
+			run: (command, args) => {
+				recorder.push({ command, args: [...args] })
+				const result: CommandResult = { stdout: response, stderr: "", exitCode: 0 }
+				return Effect.succeed(result)
+			},
+			runSchema: <S extends Schema.Top>(schema: S, command: string, args: readonly string[]) => {
+				recorder.push({ command, args: [...args] })
+				return Effect.try({
+					try: () => JSON.parse(response) as unknown,
+					catch: (cause) => cause,
+				}).pipe(Effect.flatMap((value) => Schema.decodeUnknownEffect(schema)(value))) as Effect.Effect<S["Type"], never, S["DecodingServices"]>
+			},
+		}),
+	)
+
+const releaseJson = (overrides: Record<string, unknown> = {}) =>
+	JSON.stringify({
+		id: 42,
+		tag_name: "v1.2.3",
+		target_commitish: "main",
+		name: "v1.2.3",
+		body: "Release notes",
+		draft: false,
+		prerelease: false,
+		created_at: "2026-01-01T00:00:00Z",
+		published_at: "2026-01-02T00:00:00Z",
+		html_url: "https://github.com/owner/repo/releases/tag/v1.2.3",
+		author: { login: "kit" },
+		assets: [],
+		...overrides,
+	})
+
+const runWith = <A>(effect: Effect.Effect<A, unknown, GitHubService>, layer: Layer.Layer<GitHubService>) =>
+	Effect.runPromise(effect.pipe(Effect.provide(layer)) as Effect.Effect<A>)
+
+describe("GitHubService releases", () => {
+	test("listReleases hits the paginated releases endpoint", async () => {
+		const recorder: RecordedCall[] = []
+		const layer = GitHubService.layerNoDeps.pipe(Layer.provide(fakeCommandRunner(`[${releaseJson()}]`, recorder)))
+		const page = await runWith(
+			GitHubService.use((github) => github.listReleases("owner/repo", 1, 30)),
+			layer,
+		)
+
+		expect(page.items).toHaveLength(1)
+		expect(page.items[0]!.tagName).toBe("v1.2.3")
+		expect(page.items[0]!.author?.login).toBe("kit")
+		expect(page.hasNextPage).toBe(false)
+		expect(recorder[0]!.args).toEqual(["api", "repos/owner/repo/releases?per_page=30&page=1"])
+	})
+
+	test("getRelease parses body and assets", async () => {
+		const recorder: RecordedCall[] = []
+		const json = releaseJson({
+			body: "Hello",
+			assets: [
+				{
+					id: 1,
+					name: "ghui-darwin-arm64",
+					label: null,
+					size: 1024,
+					download_count: 7,
+					content_type: "application/octet-stream",
+					browser_download_url: "https://example.com/dl",
+					url: "https://example.com/api",
+					created_at: "2026-01-01T00:00:00Z",
+					updated_at: "2026-01-01T00:00:00Z",
+				},
+			],
+		})
+		const layer = GitHubService.layerNoDeps.pipe(Layer.provide(fakeCommandRunner(json, recorder)))
+		const release = await runWith(
+			GitHubService.use((github) => github.getRelease("owner/repo", 42)),
+			layer,
+		)
+		expect(release.body).toBe("Hello")
+		expect(release.assets).toHaveLength(1)
+		expect(release.assets[0]!.name).toBe("ghui-darwin-arm64")
+		expect(recorder[0]!.args).toEqual(["api", "repos/owner/repo/releases/42"])
+	})
+
+	test("createRelease POSTs all provided fields", async () => {
+		const recorder: RecordedCall[] = []
+		const layer = GitHubService.layerNoDeps.pipe(Layer.provide(fakeCommandRunner(releaseJson(), recorder)))
+		await runWith(
+			GitHubService.use((github) =>
+				github.createRelease("owner/repo", {
+					tagName: "v1.2.3",
+					targetCommitish: "main",
+					name: "v1.2.3",
+					body: "notes",
+					draft: false,
+					prerelease: false,
+					makeLatest: "true",
+				}),
+			),
+			layer,
+		)
+		expect(recorder[0]!.args).toEqual([
+			"api",
+			"--method",
+			"POST",
+			"repos/owner/repo/releases",
+			"-f",
+			"tag_name=v1.2.3",
+			"-f",
+			"target_commitish=main",
+			"-f",
+			"name=v1.2.3",
+			"-f",
+			"body=notes",
+			"-F",
+			"draft=false",
+			"-F",
+			"prerelease=false",
+			"-f",
+			"make_latest=true",
+		])
+	})
+
+	test("updateRelease PATCHes the release endpoint", async () => {
+		const recorder: RecordedCall[] = []
+		const layer = GitHubService.layerNoDeps.pipe(Layer.provide(fakeCommandRunner(releaseJson(), recorder)))
+		await runWith(
+			GitHubService.use((github) => github.updateRelease("owner/repo", 42, { name: "renamed" })),
+			layer,
+		)
+		expect(recorder[0]!.args).toEqual(["api", "--method", "PATCH", "repos/owner/repo/releases/42", "-f", "name=renamed"])
+	})
+
+	test("deleteRelease DELETEs the release endpoint", async () => {
+		const recorder: RecordedCall[] = []
+		const layer = GitHubService.layerNoDeps.pipe(Layer.provide(fakeCommandRunner("", recorder)))
+		await runWith(
+			GitHubService.use((github) => github.deleteRelease("owner/repo", 42)),
+			layer,
+		)
+		expect(recorder[0]!.args).toEqual(["api", "--method", "DELETE", "repos/owner/repo/releases/42"])
+	})
+
+	test("generateReleaseNotes posts to the generate-notes endpoint", async () => {
+		const recorder: RecordedCall[] = []
+		const layer = GitHubService.layerNoDeps.pipe(Layer.provide(fakeCommandRunner(JSON.stringify({ name: "v1.2.3", body: "notes" }), recorder)))
+		const notes = await runWith(
+			GitHubService.use((github) => github.generateReleaseNotes("owner/repo", { tagName: "v1.2.3", previousTagName: "v1.2.2" })),
+			layer,
+		)
+		expect(notes.name).toBe("v1.2.3")
+		expect(recorder[0]!.args).toEqual(["api", "--method", "POST", "repos/owner/repo/releases/generate-notes", "-f", "tag_name=v1.2.3", "-f", "previous_tag_name=v1.2.2"])
+	})
+
+	test("listTags reads the tags endpoint with --paginate --slurp", async () => {
+		const recorder: RecordedCall[] = []
+		const layer = GitHubService.layerNoDeps.pipe(Layer.provide(fakeCommandRunner(JSON.stringify([[{ name: "v1.0.0", commit: { sha: "abc" } }]]), recorder)))
+		const tags = await runWith(
+			GitHubService.use((github) => github.listTags("owner/repo")),
+			layer,
+		)
+		expect(tags).toHaveLength(1)
+		expect(tags[0]!.name).toBe("v1.0.0")
+		expect(recorder[0]!.args).toEqual(["api", "--paginate", "--slurp", "repos/owner/repo/tags?per_page=100"])
+	})
+
+	test("getDefaultBranch reads the repo metadata", async () => {
+		const recorder: RecordedCall[] = []
+		const layer = GitHubService.layerNoDeps.pipe(Layer.provide(fakeCommandRunner(JSON.stringify({ default_branch: "trunk" }), recorder)))
+		const branch = await runWith(
+			GitHubService.use((github) => github.getDefaultBranch("owner/repo")),
+			layer,
+		)
+		expect(branch).toBe("trunk")
+		expect(recorder[0]!.args).toEqual(["api", "repos/owner/repo"])
+	})
+})


### PR DESCRIPTION
A feature I needed, creating releases.
used `gh` and TDD, and Opus 4.7, and included the plans.

happy to make changes where needed