### PR TITLE
fix: add `c` keybind to open comments in PR detail view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3126,6 +3126,7 @@ export const App = () => {
 			closeDetail: () => runCommandById("detail.close"),
 			openTheme: () => runCommandById("theme.open"),
 			openDiff: () => runCommandById("diff.open"),
+			openComments: () => runCommandById("comments.open"),
 			closePullRequest: () => runCommandById("pull.close"),
 			openLabels: () => runCommandById("pull.labels"),
 			openMerge: () => runCommandById("pull.merge"),

--- a/src/keymap/detailView.ts
+++ b/src/keymap/detailView.ts
@@ -4,6 +4,7 @@ export interface DetailViewCtx extends Scrollable {
 	readonly closeDetail: () => void
 	readonly openTheme: () => void
 	readonly openDiff: () => void
+	readonly openComments: () => void
 	readonly openReview: () => void
 	readonly closePullRequest: () => void
 	readonly openLabels: () => void
@@ -21,6 +22,7 @@ export const detailViewKeymap = Detail(
 	{ id: "detail.close", title: "Close detail", keys: ["escape", "return"], run: (s) => s.closeDetail() },
 	{ id: "detail.theme", title: "Open theme", keys: ["t"], run: (s) => s.openTheme() },
 	{ id: "detail.diff", title: "Open diff", keys: ["d"], run: (s) => s.openDiff() },
+	{ id: "detail.comments", title: "Open comments", keys: ["c"], run: (s) => s.openComments() },
 	{ id: "detail.review", title: "Review pull request", keys: ["shift+r"], run: (s) => s.openReview() },
 	{ id: "detail.close-pr", title: "Close pull request", keys: ["x"], run: (s) => s.closePullRequest() },
 	{ id: "detail.labels", title: "Manage labels", keys: ["l"], run: (s) => s.openLabels() },


### PR DESCRIPTION
Fixes #33

Currently, the PR detail view shows a row for comments with a prompt to press `c`. That does nothing.

This adds a `c` keybind to `detailViewKeymap` that uses the existing `openComments`.

Screenshot of the UI element:

<img width="320" height="38" alt="image" src="https://github.com/user-attachments/assets/2272a5a8-d775-43c3-9da1-6ddac01ff4a9" />
