### PR TITLE
fix: loading spinner stuck when PR data already cached

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -296,7 +296,9 @@ const pullRequestsAtom = githubRuntime
 					const cachedLoad = yield* cacheService.readQueue(cacheViewer, view).pipe(Effect.catch(() => Effect.succeed(null)))
 					if (cachedLoad) {
 						const cache = yield* Atom.get(queueLoadCacheAtom)
-						yield* Atom.set(queueLoadCacheAtom, trimQueueLoadCache({ ...cache, [cacheKey]: cachedLoad }))
+						if (!cache[cacheKey]) {
+							yield* Atom.set(queueLoadCacheAtom, trimQueueLoadCache({ ...cache, [cacheKey]: cachedLoad }))
+						}
 					}
 				}
 				yield* Atom.set(retryProgressAtom, initialRetryProgress)


### PR DESCRIPTION
Hello, I'm not well versed in typescript but I ran into an issue while changing repos (VIEW Open repository...) and also while re-loading. It seems to me that reload was always stuck and changing repos took super long time (looked like it was frozen for good for 5-10s)

I did some manual testing myself with the help of AI. With this one liner I have removed the stuck loading and sped up the repo loading.

## AI report
Summary

  - Guard queueLoadCacheAtom write with a cache-hit check to prevent the Effect from re-triggering itself
  in an infinite loop

  Problem

  pullRequestsAtom unconditionally writes SQLite-cached data into queueLoadCacheAtom on every run. This
  invalidates the atom reactivity graph, which restarts the Effect, which reads and writes the same cache
  again — creating an infinite loop (~3ms/cycle).

  Symptoms:
  - Loading spinner stuck permanently
  - Memory usage growing to 3-4 GB
  - UI freeze when switching repositories
  - Retries exhausted → "Refresh failed; showing cached data"

  Root cause

  In pullRequestsAtom, the SQLite cache hydration at line 299-303 calls Atom.set(queueLoadCacheAtom, ...)
  unconditionally. This write propagates through the atom graph, invalidating and restarting the very
  Effect that issued the write.

  Fix

  Skip the write if queueLoadCacheAtom already contains data for the current cache key. The SQLite cache
  only needs to be loaded into memory once — subsequent Effect runs can use what's already there.

  Diagnostics

  Confirmed via debug logging: 1690 effect starts and 1611 completions in ~35 seconds, with no active
  network connections — the effect was completing and immediately restarting. Process RSS dropped from 3.7
   GB to 232 MB after the fix.