### PR TITLE
feat: add custom queue filters via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,29 @@ Scrollable panes hide their scrollbar rails by default. Set `showScrollbars`
 to `true` to display them while retaining the same keyboard and mouse scrolling
 behavior.
 
+### Custom filters
+
+Define repo-scoped PR and issue filters that appear as additional queue tabs
+when browsing a repository:
+
+```json
+{
+	"customQueues": [
+		{ "name": "needs review", "query": "review-requested:@me is:open" },
+		{ "name": "my bugs", "query": "author:@me label:bug is:open" }
+	]
+}
+```
+
+Each entry requires a `name` (the tab label) and a `query` (a raw GitHub
+search string). When a custom filter tab is selected, ghui queries:
+
+- **Pull Requests tab**: `is:pr repo:<current-repo> <query>`
+- **Issues tab**: `is:issue repo:<current-repo> <query>`
+
+Custom filter tabs only appear when you are browsing a specific repository.
+Nothing is appended automatically beyond `is:pr`/`is:issue` and `repo:`.
+
 ### Open in editor
 
 Press `e` on a pull request (in the list, detail, or diff view) to hand it off

--- a/src/hooks/useAppShell.ts
+++ b/src/hooks/useAppShell.ts
@@ -23,7 +23,7 @@ import { selectedIndexAtom } from "../ui/listSelection/atoms.js"
 import { noticeAtom } from "../ui/notice/atoms.js"
 import { useFlashNotice } from "../ui/notice/useFlashNotice.js"
 import { useCommentMutations } from "../ui/comments/useCommentMutations.js"
-import { pullRequestDetailKey, queueSelectionAtom, usernameAtom } from "../ui/pullRequests/atoms.js"
+import { customQueuesAtom, pullRequestDetailKey, queueSelectionAtom, usernameAtom } from "../ui/pullRequests/atoms.js"
 
 import { useGitHubActions } from "./useGitHubActions.js"
 import { useImperativeActions } from "./useImperativeActions.js"
@@ -58,6 +58,7 @@ import { showScrollbarsAtom, themeIdAtom } from "../ui/theme/atoms.js"
 import { useThemeModal } from "../ui/theme/useThemeModal.js"
 import { useMergeFlow } from "../ui/merge/useMergeFlow.js"
 import { initialCommentModalState, submitReviewOptions } from "../ui/modals.js"
+import { buildFilterOptions } from "../ui/modals/FilterModal.js"
 import { useClampedIndex } from "../ui/useClampedIndex.js"
 import { useCommandHandoffs } from "./useCommandHandoffs.js"
 import { useDiffCommentDerivations } from "./useDiffCommentDerivations.js"
@@ -168,6 +169,7 @@ export const useAppShell = ({ systemThemeGeneration }: UseAppShellInput) => {
 	const [startupLoadComplete, setStartupLoadComplete] = useState(false)
 	const [homeCrumbHovered, setHomeCrumbHovered] = useState(false)
 	const usernameResult = useAtomValue(usernameAtom)
+	const customQueues = useAtomValue(customQueuesAtom)
 	const {
 		addPullRequestLabel,
 		removePullRequestLabel,
@@ -468,6 +470,7 @@ export const useAppShell = ({ systemThemeGeneration }: UseAppShellInput) => {
 		activeIssueView,
 		selectedRepository,
 		filterModal,
+		customQueues,
 		setFilterModal,
 		switchViewTo,
 		setActiveIssueView,
@@ -1275,6 +1278,7 @@ export const useAppShell = ({ systemThemeGeneration }: UseAppShellInput) => {
 			onCommentChange: setCommentEditorValue,
 			onCommentSubmit: submitCommentModal,
 			layouts: modalLayouts,
+			filterOptions: buildFilterOptions(customQueues),
 			// Picker takes over the docked panel when visible; suppressing the
 			// modal here keeps both presentations from rendering at once.
 			suppressChangedFilesModal: diffFilePanelVisible,

--- a/src/issueViews.ts
+++ b/src/issueViews.ts
@@ -3,16 +3,23 @@ import { type IssueListMode, type IssueQuery, issueQueryToListInput, type ItemLi
 // Mirrors `PullRequestView`. `Repository` means "all issues in this repo";
 // `Queue` carries the people qualifier (authored/assigned/mentioned). The
 // "all" mode is reserved for the Repository view, so Queue's mode excludes it.
+// `CustomQueue` mirrors the PR surface's custom filter — same name/query,
+// prefixed with `is:issue` instead of `is:pr`. Always repo-scoped.
 export type IssueView =
 	| { readonly _tag: "Repository"; readonly repository: string }
 	| { readonly _tag: "Queue"; readonly mode: Exclude<IssueListMode, "all">; readonly repository: string | null }
+	| { readonly _tag: "CustomQueue"; readonly name: string; readonly query: string; readonly repository: string }
 
 export const initialIssueView = (repository: string | null = null): IssueView =>
 	repository ? { _tag: "Repository", repository } : { _tag: "Queue", mode: "authored", repository: null }
 
-export const issueViewMode = (view: IssueView): IssueListMode => (view._tag === "Repository" ? "all" : view.mode)
+export const issueViewMode = (view: IssueView): IssueListMode => (view._tag === "Repository" || view._tag === "CustomQueue" ? "all" : view.mode)
 export const issueViewRepository = (view: IssueView) => view.repository
-export const issueViewToQuery = (view: IssueView): IssueQuery => ({ mode: issueViewMode(view), repository: issueViewRepository(view), textFilter: "" })
+
+export const issueViewToQuery = (view: IssueView): IssueQuery =>
+	view._tag === "CustomQueue"
+		? { mode: "all", repository: view.repository, textFilter: "", rawQualifier: view.query }
+		: { mode: issueViewMode(view), repository: issueViewRepository(view), textFilter: "" }
 
 export const issueViewToListInput = (view: IssueView, cursor: string | null, pageSize: number): ItemListInput<"issue"> =>
 	issueQueryToListInput(issueViewToQuery(view), cursor, pageSize)
@@ -20,7 +27,14 @@ export const issueViewToListInput = (view: IssueView, cursor: string | null, pag
 // Stable cache key shared with the service-seam input. PR keys start with
 // `pullRequest:`; issue keys start with `issue:`. Migration `003` relies on
 // that prefix split when pruning legacy snapshots.
-export const issueViewCacheKey = (view: IssueView) => itemQueryCacheKey("issue", issueViewToQuery(view))
+export const issueViewCacheKey = (view: IssueView): string =>
+	view._tag === "CustomQueue"
+		? `issue:custom:${view.query}:${view.repository}`
+		: itemQueryCacheKey("issue", issueViewToQuery(view))
 
-export const issueViewEquals = (left: IssueView, right: IssueView) =>
-	left._tag === right._tag && issueViewMode(left) === issueViewMode(right) && left.repository === right.repository
+export const issueViewEquals = (left: IssueView, right: IssueView): boolean => {
+	if (left._tag !== right._tag) return false
+	if (left._tag === "CustomQueue" && right._tag === "CustomQueue")
+		return left.query === right.query && left.repository === right.repository
+	return issueViewMode(left) === issueViewMode(right) && left.repository === right.repository
+}

--- a/src/item.ts
+++ b/src/item.ts
@@ -30,6 +30,9 @@ export interface ItemListInput<K extends ItemKind = ItemKind> {
 	readonly repository: string | null
 	readonly cursor: string | null
 	readonly pageSize: number
+	// When set, replaces the mode qualifier with a verbatim GitHub search string.
+	// `is:pr`/`is:issue` and `repo:` are still prepended automatically.
+	readonly rawQualifier?: string
 }
 
 // One page of items returned by the service seam, regardless of kind.
@@ -66,11 +69,17 @@ const modeQualifier = (mode: ItemListMode): string | null => {
 
 // Build the GitHub search-query string for a given list input.
 //
-// Always restricts to open items in non-archived repositories, sorted by most
-// recently updated. Throws `IllegalQueryError` for `mode: "all"` with no
-// repository — that combination means "every PR/issue on GitHub" and is never
-// intentional.
+// When `rawQualifier` is set the caller's string is used verbatim; only
+// `is:pr`/`is:issue` and `repo:` are prepended. This path is exclusively for
+// user-defined custom filters and is always called with a non-null repository.
+//
+// For built-in modes the string is fully composed here (open, non-archived,
+// sort by updated). Throws `IllegalQueryError` for `mode: "all"` with no
+// repository — that combination means "every PR/issue on GitHub".
 export const searchQualifier = (input: ItemListInput): string => {
+	if (input.rawQualifier !== undefined) {
+		return `${kindQualifier(input.kind)} repo:${input.repository} ${input.rawQualifier}`.trimEnd()
+	}
 	if (input.mode === "all" && input.repository === null) {
 		throw new IllegalQueryError(`mode "all" requires a repository; got null for kind=${input.kind}`)
 	}
@@ -83,17 +92,20 @@ export const searchQualifier = (input: ItemListInput): string => {
 }
 
 // Client-side query value. `textFilter` is local fuzzy-match and never reaches
-// the service seam.
+// the service seam. `rawQualifier` is set only for custom-filter views and is
+// forwarded to `ItemListInput` so `searchQualifier` uses it verbatim.
 export interface PullRequestQuery {
 	readonly mode: ItemListMode
 	readonly repository: string | null
 	readonly textFilter: string
+	readonly rawQualifier?: string
 }
 
 export interface IssueQuery {
 	readonly mode: IssueListMode
 	readonly repository: string | null
 	readonly textFilter: string
+	readonly rawQualifier?: string
 }
 
 export type ItemQuery = PullRequestQuery | IssueQuery
@@ -114,6 +126,7 @@ export const pullRequestQueryToListInput = (query: PullRequestQuery, cursor: str
 	repository: query.repository,
 	cursor,
 	pageSize,
+	...(query.rawQualifier !== undefined ? { rawQualifier: query.rawQualifier } : {}),
 })
 
 export const issueQueryToListInput = (query: IssueQuery, cursor: string | null, pageSize: number): ItemListInput<"issue"> => ({
@@ -122,4 +135,5 @@ export const issueQueryToListInput = (query: IssueQuery, cursor: string | null, 
 	repository: query.repository,
 	cursor,
 	pageSize,
+	...(query.rawQualifier !== undefined ? { rawQualifier: query.rawQualifier } : {}),
 })

--- a/src/pullRequestViews.ts
+++ b/src/pullRequestViews.ts
@@ -1,34 +1,55 @@
 import { pullRequestQueueLabels, pullRequestQueueModes, type PullRequestQueueMode, type PullRequestUserQueueMode } from "./domain.js"
 import { type ItemListInput, itemQueryCacheKey, pullRequestQueryToListInput, type PullRequestQuery } from "./item.js"
+import type { CustomQueueConfig } from "./themeStore.js"
 
 export type PullRequestView =
 	| { readonly _tag: "Repository"; readonly repository: string }
 	| { readonly _tag: "Queue"; readonly mode: PullRequestUserQueueMode; readonly repository: string | null }
+	// CustomQueue is always repo-scoped — `repository` is a non-null string.
+	| { readonly _tag: "CustomQueue"; readonly name: string; readonly query: string; readonly repository: string }
 
 export const initialPullRequestView = (repository: string | null = null): PullRequestView =>
 	repository ? { _tag: "Repository", repository } : { _tag: "Queue", mode: "authored", repository: null }
 
-export const viewMode = (view: PullRequestView): PullRequestQueueMode => (view._tag === "Repository" ? "repository" : view.mode)
+export const viewMode = (view: PullRequestView): PullRequestQueueMode => (view._tag === "Repository" || view._tag === "CustomQueue" ? "repository" : view.mode)
 
 export const viewRepository = (view: PullRequestView) => view.repository
 
-// Convert a view into the new unified service input. `_tag: "Repository"` is
-// the user-facing "all PRs in this repo" view → server-side `mode: "all"`.
+// Convert a view into the unified service input.
+// CustomQueue uses mode "all" + rawQualifier so the repo is always scoped
+// and the user's query string is passed through verbatim.
 export const viewToPullRequestQuery = (view: PullRequestView): PullRequestQuery =>
-	view._tag === "Repository" ? { mode: "all", repository: view.repository, textFilter: "" } : { mode: view.mode, repository: view.repository, textFilter: "" }
+	view._tag === "Repository"
+		? { mode: "all", repository: view.repository, textFilter: "" }
+		: view._tag === "CustomQueue"
+			? { mode: "all", repository: view.repository, textFilter: "", rawQualifier: view.query }
+			: { mode: view.mode, repository: view.repository, textFilter: "" }
 
 export const viewToListInput = (view: PullRequestView, cursor: string | null, pageSize: number): ItemListInput<"pullRequest"> =>
 	pullRequestQueryToListInput(viewToPullRequestQuery(view), cursor, pageSize)
 
-// Cache key is the only thing the rest of the app needs from a view; it's
-// derived through the same `itemQueryCacheKey` the service seam uses.
-export const viewCacheKey = (view: PullRequestView) => itemQueryCacheKey("pullRequest", viewToPullRequestQuery(view))
+// Custom queues include the raw query in the cache key so two queues with
+// different queries never share a bucket within the same repository.
+export const viewCacheKey = (view: PullRequestView): string =>
+	view._tag === "CustomQueue"
+		? `pullRequest:custom:${view.query}:${view.repository}`
+		: itemQueryCacheKey("pullRequest", viewToPullRequestQuery(view))
 
-export const viewEquals = (left: PullRequestView, right: PullRequestView) => left._tag === right._tag && viewMode(left) === viewMode(right) && left.repository === right.repository
+export const viewEquals = (left: PullRequestView, right: PullRequestView): boolean => {
+	if (left._tag !== right._tag) return false
+	if (left._tag === "CustomQueue" && right._tag === "CustomQueue")
+		return left.query === right.query && left.repository === right.repository
+	return viewMode(left) === viewMode(right) && left.repository === right.repository
+}
 
-export const activePullRequestViews = (view: PullRequestView): readonly PullRequestView[] => {
+// Custom queues only appear when a repository is in scope.
+export const activePullRequestViews = (view: PullRequestView, customQueues: readonly CustomQueueConfig[] = []): readonly PullRequestView[] => {
 	const repository = viewRepository(view)
-	return [...(repository ? [{ _tag: "Repository" as const, repository }] : []), ...pullRequestQueueModes.map((mode) => ({ _tag: "Queue" as const, mode, repository }))]
+	return [
+		...(repository ? [{ _tag: "Repository" as const, repository }] : []),
+		...pullRequestQueueModes.map((mode) => ({ _tag: "Queue" as const, mode, repository })),
+		...(repository ? customQueues.map(({ name, query }) => ({ _tag: "CustomQueue" as const, name, query, repository })) : []),
+	]
 }
 
 export const nextView = (view: PullRequestView, views: readonly PullRequestView[], delta: 1 | -1) => {
@@ -39,7 +60,8 @@ export const nextView = (view: PullRequestView, views: readonly PullRequestView[
 	return views[(index + delta + views.length) % views.length]!
 }
 
-export const viewLabel = (view: PullRequestView) => (view._tag === "Repository" ? view.repository : pullRequestQueueLabels[view.mode])
+export const viewLabel = (view: PullRequestView) =>
+	view._tag === "Repository" ? view.repository : view._tag === "CustomQueue" ? view.name : pullRequestQueueLabels[view.mode]
 
 export const parseRepositoryInput = (input: string) => {
 	const trimmed = input.trim()

--- a/src/services/CacheService.ts
+++ b/src/services/CacheService.ts
@@ -92,6 +92,7 @@ const CachedPullRequestItemSchema = Schema.Struct({
 const CachedPullRequestViewSchema = Schema.Union([
 	Schema.Struct({ _tag: Schema.tag("Queue"), mode: Schema.Literals(pullRequestQueueModes), repository: Schema.NullOr(Schema.String) }),
 	Schema.Struct({ _tag: Schema.tag("Repository"), repository: Schema.String }),
+	Schema.Struct({ _tag: Schema.tag("CustomQueue"), name: Schema.String, query: Schema.String, repository: Schema.String }),
 ])
 
 // IssueView's Queue mode excludes "all" — that mode is reserved for the
@@ -102,6 +103,7 @@ const issueQueueModes = ["authored", "assigned", "mentioned"] as const
 const CachedIssueViewSchema = Schema.Union([
 	Schema.Struct({ _tag: Schema.tag("Queue"), mode: Schema.Literals(issueQueueModes), repository: Schema.NullOr(Schema.String) }),
 	Schema.Struct({ _tag: Schema.tag("Repository"), repository: Schema.String }),
+	Schema.Struct({ _tag: Schema.tag("CustomQueue"), name: Schema.String, query: Schema.String, repository: Schema.String }),
 ])
 
 const issueStates = ["open", "closed"] as const

--- a/src/surfaces/WorkspaceModals.tsx
+++ b/src/surfaces/WorkspaceModals.tsx
@@ -1,6 +1,7 @@
 import type { AppCommand } from "../commands.js"
 import type { PullRequestLabel, PullRequestReviewComment } from "../domain.js"
 import { CommandPalette } from "../ui/CommandPalette.js"
+import type { FilterOption } from "../ui/modals/FilterModal.js"
 import {
 	ChangedFilesModal,
 	type ChangedFileSearchResult,
@@ -47,6 +48,7 @@ export interface WorkspaceModalsProps {
 	// When the docked diff-file panel is rendering the picker inline, the
 	// modal must stand down so both presentations don't fight for the screen.
 	readonly suppressChangedFilesModal: boolean
+	readonly filterOptions: readonly FilterOption[]
 }
 
 const layoutToProps = (layout: ModalLayout) => ({
@@ -80,7 +82,7 @@ export const WorkspaceModals = (props: WorkspaceModalsProps) =>
 			props.suppressChangedFilesModal ? null : (
 				<ChangedFilesModal state={state} results={props.changedFileResults} totalCount={props.readyDiffFileCount} {...layoutToProps(props.layouts.ChangedFiles)} />
 			),
-		Filter: (state) => <FilterModal state={state} {...layoutToProps(props.layouts.Filter)} />,
+		Filter: (state) => <FilterModal state={state} options={props.filterOptions} {...layoutToProps(props.layouts.Filter)} />,
 		SubmitReview: (state) => <SubmitReviewModal state={state} {...layoutToProps(props.layouts.SubmitReview)} />,
 		Theme: (state) => <ThemeModal state={state} {...layoutToProps(props.layouts.Theme)} />,
 		OpenRepository: (state) => <OpenRepositoryModal state={state} {...layoutToProps(props.layouts.OpenRepository)} />,

--- a/src/themeStore.ts
+++ b/src/themeStore.ts
@@ -16,6 +16,25 @@ interface StoredConfig {
 	readonly showScrollbars?: unknown
 	readonly editorCommand?: unknown
 	readonly repoPaths?: unknown
+	readonly customQueues?: unknown
+}
+
+export interface CustomQueueConfig {
+	readonly name: string
+	readonly query: string
+}
+
+const parseCustomQueues = (value: unknown): readonly CustomQueueConfig[] => {
+	if (!Array.isArray(value)) return []
+	return value.filter(
+		(item): item is CustomQueueConfig =>
+			!!item &&
+			typeof item === "object" &&
+			typeof (item as Record<string, unknown>).name === "string" &&
+			((item as Record<string, unknown>).name as string).length > 0 &&
+			typeof (item as Record<string, unknown>).query === "string" &&
+			((item as Record<string, unknown>).query as string).length > 0,
+	)
 }
 
 const configDirectory = () => {
@@ -98,6 +117,14 @@ export const loadStoredEditorConfig: Effect.Effect<StoredEditorConfig> = Effect.
 		return { editorCommand, repoPaths: parseRepoPaths(config.repoPaths) }
 	}),
 	() => Effect.succeed({ editorCommand: null, repoPaths: {} } satisfies StoredEditorConfig),
+)
+
+export const loadStoredCustomQueues: Effect.Effect<readonly CustomQueueConfig[]> = Effect.catchCause(
+	Effect.tryPromise(async () => {
+		const config = await readStoredConfig()
+		return parseCustomQueues(config.customQueues)
+	}),
+	() => Effect.succeed([]),
 )
 
 export const saveStoredThemeId = (theme: ThemeId): Effect.Effect<void> =>

--- a/src/ui/filter/useFilterModal.ts
+++ b/src/ui/filter/useFilterModal.ts
@@ -1,8 +1,9 @@
 import { devLog } from "../../devLog.js"
 import { type IssueView, issueViewEquals } from "../../issueViews.js"
 import type { PullRequestView } from "../../pullRequestViews.js"
+import type { CustomQueueConfig } from "../../themeStore.js"
 import type { WorkspaceSurface } from "../../workspaceSurfaces.js"
-import { filterOptions } from "../modals/FilterModal.js"
+import { buildFilterOptions } from "../modals/FilterModal.js"
 import type { FilterModalState } from "../modals/types.js"
 
 // Duplicated in App.tsx, useMergeFlow, and useThemeModal — small enough to
@@ -15,6 +16,7 @@ export interface UseFilterModalInput {
 	readonly activeIssueView: IssueView
 	readonly selectedRepository: string | null
 	readonly filterModal: FilterModalState
+	readonly customQueues: readonly CustomQueueConfig[]
 	readonly setFilterModal: (next: FilterModalState | ((prev: FilterModalState) => FilterModalState)) => void
 	readonly switchViewTo: (view: PullRequestView) => void
 	readonly setActiveIssueView: (view: IssueView) => void
@@ -48,6 +50,7 @@ export const useFilterModal = ({
 	activeIssueView,
 	selectedRepository,
 	filterModal,
+	customQueues,
 	setFilterModal,
 	switchViewTo,
 	setActiveIssueView,
@@ -56,39 +59,43 @@ export const useFilterModal = ({
 	resetLoadingMoreIssues,
 	bumpRefreshGeneration,
 }: UseFilterModalInput): UseFilterModalResult => {
+	const options = buildFilterOptions(customQueues)
+
+	const activeFilterValue = (): string => {
+		const view = activeWorkspaceSurface === "pullRequests" ? activeView : activeIssueView
+		if (view._tag === "CustomQueue") return `custom:${view.name}`
+		if (view._tag === "Queue" && view.mode === "authored") return "mine"
+		return "all"
+	}
+
 	const openFilterModal = () => {
 		if (!selectedRepository || (activeWorkspaceSurface !== "pullRequests" && activeWorkspaceSurface !== "issues")) return
-		const isMine =
-			activeWorkspaceSurface === "pullRequests"
-				? activeView._tag === "Queue" && activeView.mode === "authored"
-				: activeIssueView._tag === "Queue" && activeIssueView.mode === "authored"
+		const currentValue = activeFilterValue()
 		setFilterModal({
 			surface: activeWorkspaceSurface,
-			selectedIndex: Math.max(
-				0,
-				filterOptions.findIndex((option) => option.value === (isMine ? "mine" : "all")),
-			),
+			selectedIndex: Math.max(0, options.findIndex((option) => option.value === currentValue)),
 		})
 	}
 
 	const moveFilterSelection = (delta: -1 | 1) => {
-		setFilterModal((current) => ({ ...current, selectedIndex: wrapIndex(current.selectedIndex + delta, filterOptions.length) }))
+		setFilterModal((current) => ({ ...current, selectedIndex: wrapIndex(current.selectedIndex + delta, options.length) }))
 	}
 
 	const applySelectedFilter = () => {
-		const option = filterOptions[filterModal.selectedIndex]
+		const option = options[filterModal.selectedIndex]
 		devLog("applySelectedFilter", { option, surface: filterModal.surface, selectedRepository, activeView, activeIssueView })
-		if (!option) return
-		if (filterModal.surface === "pullRequests" && selectedRepository) {
+		if (!option || !selectedRepository) return
+
+		if (option.customQueue) {
+			const { name, query } = option.customQueue
+			switchViewTo({ _tag: "CustomQueue", name, query, repository: selectedRepository })
+			// Issue view is synced automatically via issueViewForPullRequestView in switchViewTo.
+		} else if (filterModal.surface === "pullRequests") {
 			switchViewTo(option.value === "mine" ? { _tag: "Queue", mode: "authored", repository: selectedRepository } : { _tag: "Repository", repository: selectedRepository })
-		} else if (filterModal.surface === "issues" && selectedRepository) {
+		} else if (filterModal.surface === "issues") {
 			const nextView: IssueView =
 				option.value === "mine" ? { _tag: "Queue", mode: "authored", repository: selectedRepository } : { _tag: "Repository", repository: selectedRepository }
 			if (!issueViewEquals(nextView, activeIssueView)) {
-				// Mirror the resets `switchViewTo` does for PR-side filter
-				// changes. Without these, the previous queue's load-more
-				// state can land on the new view and stale selection sticks
-				// past the visible row count.
 				bumpRefreshGeneration()
 				setSelectedIssueIndex(0)
 				resetLoadingMoreIssues()

--- a/src/ui/modals/FilterModal.tsx
+++ b/src/ui/modals/FilterModal.tsx
@@ -6,30 +6,46 @@ import type { FilterModalState } from "./types.js"
 
 export interface FilterOption {
 	readonly label: string
-	readonly value: ScopeFilter
+	readonly value: ScopeFilter | string
 	readonly description: string
+	readonly customQueue?: { readonly name: string; readonly query: string }
 }
 
-export const filterOptions: readonly FilterOption[] = [
+const builtInFilterOptions: readonly FilterOption[] = [
 	{ label: "all", value: "all", description: "show all items in this view" },
 	{ label: "author:@me", value: "mine", description: "authored by me" },
 ]
 
+export const buildFilterOptions = (customQueues: readonly { readonly name: string; readonly query: string }[]): readonly FilterOption[] => [
+	...builtInFilterOptions,
+	...customQueues.map(({ name, query }) => ({
+		label: name,
+		value: `custom:${name}`,
+		description: query,
+		customQueue: { name, query },
+	})),
+]
+
+// Kept for callers that don't have custom queues available.
+export const filterOptions = builtInFilterOptions
+
 export const FilterModal = ({
 	state,
+	options = builtInFilterOptions,
 	modalWidth,
 	modalHeight,
 	offsetLeft,
 	offsetTop,
 }: {
 	readonly state: FilterModalState
+	readonly options?: readonly FilterOption[]
 	readonly modalWidth: number
 	readonly modalHeight: number
 	readonly offsetLeft: number
 	readonly offsetTop: number
 }) => {
 	const title = state.surface === "issues" ? "Filter Issues" : "Filter Pull Requests"
-	const selectedIndex = Math.max(0, Math.min(state.selectedIndex, filterOptions.length - 1))
+	const selectedIndex = Math.max(0, Math.min(state.selectedIndex, options.length - 1))
 	const { rowWidth, bodyHeight } = standardModalDims(modalWidth, modalHeight)
 	return (
 		<StandardModal
@@ -53,7 +69,7 @@ export const FilterModal = ({
 				/>
 			}
 		>
-			{filterOptions.map((option, index) => {
+			{options.map((option, index) => {
 				const selected = index === selectedIndex
 				const descriptionWidth = Math.max(1, rowWidth - option.label.length - 4)
 				return (
@@ -68,7 +84,7 @@ export const FilterModal = ({
 					</TextLine>
 				)
 			})}
-			<Filler rows={Math.max(0, bodyHeight - filterOptions.length)} prefix="filter-modal" />
+			<Filler rows={Math.max(0, bodyHeight - options.length)} prefix="filter-modal" />
 		</StandardModal>
 	)
 }

--- a/src/ui/pullRequests/atoms.ts
+++ b/src/ui/pullRequests/atoms.ts
@@ -12,6 +12,7 @@ import { freshPullRequestLoad, mergePullRequestDetail } from "../../pullRequestC
 export { nextLoadAfterPage } from "../../pullRequestCache.js"
 import type { PullRequestLoad } from "../../pullRequestLoad.js"
 import { activePullRequestViews, initialPullRequestView, type PullRequestView, viewCacheKey, viewRepository, viewToListInput } from "../../pullRequestViews.js"
+import { loadStoredCustomQueues, type CustomQueueConfig } from "../../themeStore.js"
 import { CacheService } from "../../services/CacheService.js"
 import { GitHubService } from "../../services/GitHubService.js"
 import { githubRuntime, pullRequestPageSize } from "../../services/runtime.js"
@@ -53,6 +54,9 @@ export const retryProgressAtom = Atom.make<RetryProgress>(initialRetryProgress).
 export const activeViewAtom = Atom.make<PullRequestView>(initialPullRequestView(null)).pipe(Atom.keepAlive)
 export const queueLoadCacheAtom = Atom.make<Partial<Record<string, PullRequestLoad>>>({}).pipe(Atom.keepAlive)
 export const queueSelectionAtom = Atom.make<Partial<Record<string, number>>>({}).pipe(Atom.keepAlive)
+export const customQueuesAtom = Atom.make<readonly CustomQueueConfig[]>(
+	await Effect.runPromise(loadStoredCustomQueues),
+).pipe(Atom.keepAlive)
 
 // === Data-fetching atoms ===
 //
@@ -245,7 +249,7 @@ export const pullRequestStatusAtom = Atom.make((get): LoadStatus => {
 	return "ready"
 })
 
-export const activeViewsAtom = Atom.make((get) => activePullRequestViews(get(activeViewAtom)))
+export const activeViewsAtom = Atom.make((get) => activePullRequestViews(get(activeViewAtom), get(customQueuesAtom)))
 export const loadedPullRequestCountAtom = Atom.make((get) => cachedPullRequestLoad(get)?.data.length ?? 0)
 export const hasMorePullRequestsAtom = Atom.make((get) => {
 	const load = cachedPullRequestLoad(get)

--- a/src/viewSync.ts
+++ b/src/viewSync.ts
@@ -16,6 +16,7 @@ import type { PullRequestView } from "./pullRequestViews.js"
 // would skip the sync and leave the issue view stuck on a stale value.
 export const issueViewForPullRequestView = (view: PullRequestView): IssueView => {
 	if (view._tag === "Repository") return { _tag: "Repository", repository: view.repository }
+	if (view._tag === "CustomQueue") return { _tag: "CustomQueue", name: view.name, query: view.query, repository: view.repository }
 	if (view.repository === null) return { _tag: "Queue", mode: "authored", repository: null }
 	return { _tag: "Repository", repository: view.repository }
 }


### PR DESCRIPTION
Adds a `customQueues` config option that lets users define additional queue tabs scoped to the current repository. Each entry has a `name` (tab label) and a `query` (raw GitHub search string). When selected, ghui queries `is:pr repo:<repo> <query>` for the PR tab and `is:issue repo:<repo> <query>` for the Issues tab simultaneously.

Fixes #50

***

_Please note that it has been a while since I wrote any j/ts, so almost of this PR was spun up by Claude. If this doesn't make sense, feel free to close this out or suggest changes, and I'll proceed accordingly. Thank you for developing this tool!_