### PR TITLE
feat: add a launch-scoped theme override

### DIFF
--- a/.changeset/launch-theme-override.md
+++ b/.changeset/launch-theme-override.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/ghui": minor
+---
+
+Allow terminal hosts and wrappers to select a theme for one launch with `GHUI_THEME` without changing saved preferences.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ bun run dev
 
 - `GHUI_PR_FETCH_LIMIT`: max PRs fetched, defaults to `200`
 - `GHUI_RUN_FETCH_LIMIT`: max workflow runs fetched per PR, defaults to `20`
+- `GHUI_THEME`: valid theme ID to use for this launch without changing saved preferences
 
 Example:
 

--- a/src/themeStore.ts
+++ b/src/themeStore.ts
@@ -27,6 +27,11 @@ const configDirectory = () => {
 
 export const configPath = () => join(configDirectory(), "config.json")
 
+const launchThemeOverride = (): ThemeId | null => {
+	const theme = process.env.GHUI_THEME?.trim()
+	return isThemeId(theme) ? theme : null
+}
+
 const parseConfig = (text: string): StoredConfig => {
 	const value = JSON.parse(text) as unknown
 	return value && typeof value === "object" ? value : {}
@@ -52,7 +57,10 @@ export const loadStoredThemeId: Effect.Effect<ThemeId> = Effect.catchCause(
 )
 
 export const loadStoredThemeConfig: Effect.Effect<ThemeConfig> = Effect.catchCause(
-	Effect.tryPromise(async () => normalizeThemeConfig(await readStoredConfig())),
+	Effect.tryPromise(async () => {
+		const override = launchThemeOverride()
+		return override ? { mode: "fixed", theme: override } : normalizeThemeConfig(await readStoredConfig())
+	}),
 	() => Effect.succeed(normalizeThemeConfig({})),
 )
 

--- a/test/themeStore.test.ts
+++ b/test/themeStore.test.ts
@@ -3,9 +3,10 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { Effect } from "effect"
-import { loadStoredEditorConfig, loadStoredShowScrollbars, loadStoredSystemThemeAutoReload } from "../src/themeStore.js"
+import { loadStoredEditorConfig, loadStoredShowScrollbars, loadStoredSystemThemeAutoReload, loadStoredThemeConfig } from "../src/themeStore.js"
 
 const originalConfigDir = process.env.GHUI_CONFIG_DIR
+const originalTheme = process.env.GHUI_THEME
 const tempDirs: string[] = []
 
 const restoreConfigDir = () => {
@@ -16,8 +17,17 @@ const restoreConfigDir = () => {
 	}
 }
 
+const restoreTheme = () => {
+	if (originalTheme === undefined) {
+		delete process.env.GHUI_THEME
+	} else {
+		process.env.GHUI_THEME = originalTheme
+	}
+}
+
 afterEach(async () => {
 	restoreConfigDir()
+	restoreTheme()
 	await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })))
 	tempDirs.length = 0
 })
@@ -75,6 +85,24 @@ describe("loadStoredShowScrollbars", () => {
 		await useTempConfig('{"showScrollbars":"true"}')
 
 		expect(await loadShowScrollbars()).toBe(false)
+	})
+})
+
+const loadThemeConfig = () => Effect.runPromise(loadStoredThemeConfig)
+
+describe("loadStoredThemeConfig", () => {
+	test("uses a valid launch theme instead of the persisted theme", async () => {
+		await useTempConfig('{"theme":"dracula","themeMode":"fixed"}')
+		process.env.GHUI_THEME = "system"
+
+		expect(await loadThemeConfig()).toEqual({ mode: "fixed", theme: "system" })
+	})
+
+	test("ignores an invalid launch theme", async () => {
+		await useTempConfig('{"theme":"dracula","themeMode":"fixed"}')
+		process.env.GHUI_THEME = "not-a-theme"
+
+		expect(await loadThemeConfig()).toEqual({ mode: "fixed", theme: "dracula" })
 	})
 })
 


### PR DESCRIPTION
this adds a small launch-scoped theme override through `GHUI_THEME`.

terminal hosts and wrappers can use it to select a theme for one ghui process without rewriting the user's saved preferences. unknown theme ids are ignored and ghui falls back to the saved config.

for example, `GHUI_THEME=system ghui` lets ghui read the launching terminal's colors while keeping the user's normal theme choice unchanged for other launches.