### PR TITLE
fix(commands): restore copied item metadata

### DIFF
--- a/.changeset/restore-copied-metadata.md
+++ b/.changeset/restore-copied-metadata.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/ghui": patch
+---
+
+Restore branch, review, and check details when copying pull request metadata, and comment counts and labels when copying issue metadata.

--- a/src/commands/builtins.ts
+++ b/src/commands/builtins.ts
@@ -18,6 +18,7 @@ import { initialCommandPaletteState, initialCommentModalState, initialOpenReposi
 import { noticeAtom } from "../ui/notice/atoms.js"
 import type { PullRequestUserQueueMode } from "../domain.js"
 import { pullRequestQueueModes } from "../domain.js"
+import { issueMetadataText, pullRequestMetadataText } from "../ui/pullRequests.js"
 import { labelCacheAtom, selectedPullRequestAtom } from "../ui/pullRequests/atoms.js"
 import { selectedRepositoryAtom, workspaceSurfaceAtom, workspaceTabSurfacesAtom } from "../workspace/atoms.js"
 import { type WorkspaceSurface, workspaceSurfaceLabels, workspaceSurfaces } from "../workspaceSurfaces.js"
@@ -524,7 +525,7 @@ export const globalCommands: readonly CommandDefinition[] = [
 		run: Effect.gen(function* () {
 			const pr = yield* Atom.get(selectedPullRequestAtom)
 			if (!pr) return
-			const text = `${pr.repository}#${pr.number} ${pr.title}\n${pr.url}`
+			const text = pullRequestMetadataText(pr)
 			yield* Clipboard.use((clipboard) => clipboard.copy(text)).pipe(
 				Effect.tap(() => Atom.set(noticeAtom, "Pull request metadata copied")),
 				Effect.catch(flashErrorEffect),
@@ -542,7 +543,7 @@ export const globalCommands: readonly CommandDefinition[] = [
 		run: Effect.gen(function* () {
 			const issue = yield* Atom.get(selectedIssueAtom)
 			if (!issue) return
-			const text = `${issue.repository}#${issue.number} ${issue.title}\n${issue.url}`
+			const text = issueMetadataText(issue)
 			yield* Clipboard.use((clipboard) => clipboard.copy(text)).pipe(
 				Effect.tap(() => Atom.set(noticeAtom, "Issue metadata copied")),
 				Effect.catch(flashErrorEffect),

--- a/test/commandRuntime.test.ts
+++ b/test/commandRuntime.test.ts
@@ -32,6 +32,87 @@ describe("command runtime", () => {
 		})
 	})
 
+	test("pull.copy-metadata copies branch, review, and check metadata", async () => {
+		const probe = `
+			import { Effect } from "effect"
+			import * as AtomRegistry from "effect/unstable/reactivity/AtomRegistry"
+			import { dispatchCommand } from "./src/commands/dispatch.ts"
+			import { Clipboard } from "./src/services/Clipboard.ts"
+			import { noticeAtom } from "./src/ui/notice/atoms.ts"
+			import { selectedPullRequestAtom } from "./src/ui/pullRequests/atoms.ts"
+			import { workspaceSurfaceAtom } from "./src/workspace/atoms.ts"
+			const registry = AtomRegistry.make({ initialValues: [
+				[workspaceSurfaceAtom, "pullRequests"],
+				[selectedPullRequestAtom, {
+					repository: "owner/repo", number: 42, title: "Fix metadata copying",
+					url: "https://github.com/owner/repo/pull/42",
+					headRefName: "fix/metadata", baseRefName: "main", reviewStatus: "approved",
+					checkSummary: "checks 2/4",
+					checks: [
+						{ name: "lint", status: "completed", conclusion: "success" },
+						{ name: "test", status: "completed", conclusion: "failure" },
+						{ name: "build", status: "completed", conclusion: "timed_out" },
+						{ name: "docs", status: "completed", conclusion: "skipped" },
+					],
+				}],
+			] })
+			const copies = []
+			await Effect.runPromise(dispatchCommand("pull.copy-metadata").pipe(
+				Effect.provideService(AtomRegistry.AtomRegistry, registry),
+				Effect.provideService(Clipboard, { copy: (text) => Effect.sync(() => { copies.push(text) }) }),
+			))
+			console.log(JSON.stringify({ copies, notice: registry.get(noticeAtom) }))
+			registry.dispose()
+		`
+		const stdout = await runIsolatedProbe(probe)
+		expect(JSON.parse(stdout)).toEqual({
+			copies: [
+				[
+					"Fix metadata copying",
+					"owner/repo #42",
+					"https://github.com/owner/repo/pull/42",
+					"branch: fix/metadata -> main",
+					"review: approved",
+					"checks 2/4",
+					"failing checks: test, build",
+				].join("\n"),
+			],
+			notice: "Pull request metadata copied",
+		})
+	})
+
+	test("issue.copy-metadata copies comment count and labels", async () => {
+		const probe = `
+			import { Effect } from "effect"
+			import * as AtomRegistry from "effect/unstable/reactivity/AtomRegistry"
+			import { dispatchCommand } from "./src/commands/dispatch.ts"
+			import { Clipboard } from "./src/services/Clipboard.ts"
+			import { selectedIssueAtom } from "./src/ui/issues/atoms.ts"
+			import { noticeAtom } from "./src/ui/notice/atoms.ts"
+			import { workspaceSurfaceAtom } from "./src/workspace/atoms.ts"
+			const registry = AtomRegistry.make({ initialValues: [
+				[workspaceSurfaceAtom, "issues"],
+				[selectedIssueAtom, {
+					repository: "owner/repo", number: 43, title: "Missing clipboard fields",
+					url: "https://github.com/owner/repo/issues/43", commentCount: 3,
+					labels: [{ name: "bug", color: null }, { name: "clipboard", color: null }],
+				}],
+			] })
+			const copies = []
+			await Effect.runPromise(dispatchCommand("issue.copy-metadata").pipe(
+				Effect.provideService(AtomRegistry.AtomRegistry, registry),
+				Effect.provideService(Clipboard, { copy: (text) => Effect.sync(() => { copies.push(text) }) }),
+			))
+			console.log(JSON.stringify({ copies, notice: registry.get(noticeAtom) }))
+			registry.dispose()
+		`
+		const stdout = await runIsolatedProbe(probe)
+		expect(JSON.parse(stdout)).toEqual({
+			copies: [["Missing clipboard fields", "owner/repo #43", "https://github.com/owner/repo/issues/43", "3 comments", "labels: bug, clipboard"].join("\n")],
+			notice: "Issue metadata copied",
+		})
+	})
+
 	test("handoff cleanup cannot remove a newer registration", () => {
 		const calls: string[] = []
 		const cleanFirst = registerHandoff("quit", () => calls.push("first"))


### PR DESCRIPTION
## Why

Copying PR or issue metadata produces only the item summary and URL. The command migration in `2fb320c` dropped the existing metadata formatters, silently removing fields users previously received.

## What Changes

Reconnect both commands to the existing formatters.

| Item | Restored Clipboard Fields |
| --- | --- |
| Pull request | Separate title and repository/number lines, head/base branch, review status, check summary, failing check names |
| Issue | Separate title and repository/number lines, comment count, labels |

The PR regression captures `branch: fix/metadata -> main`, `review: approved`, `checks 2/4`, and `failing checks: test, build`. The issue regression captures `3 comments` and `labels: bug, clipboard`.

## Scope

Only command wiring, two real-command regression tests, and a patch changeset. Formatting rules, command gating, and success/error handling remain unchanged. Clipboard verification uses an isolated capturing service, not the system clipboard.

## Verification

```bash
bun install --frozen-lockfile
bun run test --test-name-pattern 'copy-metadata'
bun run format:check
bun run typecheck
bun run lint
bun run test
bun run test:keymap
bun run changeset:status
git diff --check
```

Both command regressions failed with the truncated output before the fix and pass afterward. The full suite passes 544 tests; the keymap suite passes 131 tests. Formatting, typechecking, lint, and diff checks pass. Changeset status reports a patch bump only. Package smoke and release commands were not run for this command-only change.
