### PR TITLE
fix(merge): support merge queue targets

### DIFF
--- a/.changeset/merge-queue-targets.md
+++ b/.changeset/merge-queue-targets.md
@@ -1,0 +1,5 @@
+---
+"@kitlangton/ghui": patch
+---
+
+Fix merging pull requests into branches with a merge queue: avoid requesting branch deletion, keep queued pull requests open while refreshing, and report queue requests separately from completed merges. Admin merges still explicitly bypass the queue.

--- a/.changeset/merge-queue-targets.md
+++ b/.changeset/merge-queue-targets.md
@@ -2,4 +2,4 @@
 "@kitlangton/ghui": patch
 ---
 
-Fix merging pull requests into branches with a merge queue: avoid requesting branch deletion, keep queued pull requests open while refreshing, and report queue requests separately from completed merges. Admin merges still explicitly bypass the queue.
+Fix merging pull requests into branches with a merge queue: avoid requesting branch deletion, keep queued pull requests open while refreshing, and report queue requests separately from completed merges. Admin merges still explicitly bypass the queue. Block merge confirmation after lookup failures.

--- a/src/domain.ts
+++ b/src/domain.ts
@@ -60,6 +60,7 @@ export type PullRequestMergeAction =
 	| {
 			readonly kind: PullRequestMergeMethodKind
 			readonly method: PullRequestMergeMethod
+			readonly mergeQueueEnabled: boolean
 	  }
 	| {
 			readonly kind: "disable-auto"
@@ -254,4 +255,5 @@ export interface PullRequestMergeInfo {
 	readonly checkSummary: string | null
 	readonly autoMergeEnabled: boolean
 	readonly viewerCanMergeAsAdmin: boolean
+	readonly mergeQueueEnabled: boolean
 }

--- a/src/keymap/contexts/mergeModalCtx.ts
+++ b/src/keymap/contexts/mergeModalCtx.ts
@@ -12,7 +12,7 @@ export interface BuildMergeModalCtxInput {
 }
 
 export const buildMergeModalCtx = ({ mergeModal, cancelOrCloseMergeModal, confirmMergeAction, cycleMergeMethod, moveMergeSelection }: BuildMergeModalCtxInput): MergeModalCtx => ({
-	availableActionCount: visibleMergeKinds(mergeModal.info, mergeModal.allowedMethods, mergeModal.selectedMethod).length,
+	availableActionCount: mergeModal.error ? 0 : visibleMergeKinds(mergeModal.info, mergeModal.allowedMethods, mergeModal.selectedMethod).length,
 	multipleMethodsAllowed: mergeModal.allowedMethods ? allowedMergeMethodList(mergeModal.allowedMethods).length > 1 : false,
 	inConfirmMode: mergeModal.pendingConfirm !== null,
 	closeOrBackOut: cancelOrCloseMergeModal,

--- a/src/mergeActions.ts
+++ b/src/mergeActions.ts
@@ -105,7 +105,7 @@ export const mergeKinds: readonly MergeKindDefinition[] = Object.values(mergeKin
 
 export const availableMergeKinds = (info: PullRequestMergeInfo | null): readonly MergeKindDefinition[] => {
 	if (!info) return []
-	return mergeKinds.filter((kind) => kind.isAvailable(info))
+	return mergeKinds.filter((kind) => kind.isAvailable(info)).map((kind) => getMergeKindDefinition(kind.kind, info.mergeQueueEnabled))
 }
 
 export const visibleMergeKinds = (info: PullRequestMergeInfo | null, allowed: RepositoryMergeMethods | null, selected: PullRequestMergeMethod): readonly MergeKindDefinition[] => {
@@ -126,14 +126,27 @@ export const mergeKindRowTitle = (kind: MergeKindDefinition, method: PullRequest
 	return `Mark ready & ${baseTitle.charAt(0).toLowerCase()}${baseTitle.slice(1)}`
 }
 
-export const getMergeKindDefinition = (kind: PullRequestMergeKind): MergeKindDefinition => mergeKindDefinitions[kind]
+export const getMergeKindDefinition = (kind: PullRequestMergeKind, mergeQueueEnabled: boolean): MergeKindDefinition => {
+	const definition = mergeKindDefinitions[kind]
+	if (!mergeQueueEnabled || kind === "disable-auto") return definition
+	if (kind === "admin") return { ...definition, description: () => "Bypass the merge queue and merge directly with --admin." }
+	return {
+		...definition,
+		title: () => (kind === "now" ? "Add to merge queue" : "Enable merge queue when ready"),
+		description: () => "Queue when requirements pass; GitHub chooses the merge method.",
+		pastTense: () => "Requested merge queue for",
+		refreshOnSuccess: true,
+	}
+}
 
 export const mergeActionCliArgs = (action: PullRequestMergeAction): readonly string[] => {
 	if (action.kind === "disable-auto") return ["--disable-auto"]
 	const methodFlag = methodCopy[action.method].cliFlag
-	if (action.kind === "now") return [methodFlag, "--delete-branch"]
-	if (action.kind === "auto") return [methodFlag, "--auto", "--delete-branch"]
-	return [methodFlag, "--admin", "--delete-branch"]
+	// gh rejects branch deletion for queue targets, even with --admin.
+	const deleteBranch = action.mergeQueueEnabled ? [] : ["--delete-branch"]
+	if (action.kind === "now") return [methodFlag, ...deleteBranch]
+	if (action.kind === "auto") return [methodFlag, "--auto", ...deleteBranch]
+	return [methodFlag, "--admin", ...deleteBranch]
 }
 
 export const mergeInfoFromPullRequest = (pullRequest: PullRequestItem): PullRequestMergeInfo => ({
@@ -148,4 +161,5 @@ export const mergeInfoFromPullRequest = (pullRequest: PullRequestItem): PullRequ
 	checkSummary: pullRequest.checkSummary,
 	autoMergeEnabled: pullRequest.autoMergeEnabled,
 	viewerCanMergeAsAdmin: false,
+	mergeQueueEnabled: false,
 })

--- a/src/services/GitHubService.ts
+++ b/src/services/GitHubService.ts
@@ -359,11 +359,16 @@ export class GitHubService extends Context.Service<
 							"-F",
 							`number=${number}`,
 							"-f",
-							"query=query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { viewerCanMergeAsAdmin } } }",
+							"query=query($owner: String!, $name: String!, $number: Int!) { repository(owner: $owner, name: $name) { pullRequest(number: $number) { viewerCanMergeAsAdmin mergeQueue { id } } } }",
 						])
 					: null
 
-				return parsePullRequestMergeInfo(repository, info, adminInfo?.data.repository.pullRequest?.viewerCanMergeAsAdmin ?? false)
+				return parsePullRequestMergeInfo(
+					repository,
+					info,
+					adminInfo?.data.repository.pullRequest?.viewerCanMergeAsAdmin ?? false,
+					Boolean(adminInfo?.data.repository.pullRequest?.mergeQueue),
+				)
 			})
 
 			const getRepositoryMergeMethods = Effect.fn("GitHubService.getRepositoryMergeMethods")(function* (repository: string) {

--- a/src/services/githubNormalize.ts
+++ b/src/services/githubNormalize.ts
@@ -299,7 +299,7 @@ export const parseRunDetails = (details: RawWorkflowRunDetails): WorkflowRunDeta
 
 type RawMergeInfo = Schema.Schema.Type<typeof MergeInfoResponseSchema>
 
-export const parsePullRequestMergeInfo = (repository: string, info: RawMergeInfo, viewerCanMergeAsAdmin: boolean): PullRequestMergeInfo => {
+export const parsePullRequestMergeInfo = (repository: string, info: RawMergeInfo, viewerCanMergeAsAdmin: boolean, mergeQueueEnabled: boolean): PullRequestMergeInfo => {
 	const checkInfo = getCheckInfoFromContexts(info.statusCheckRollup)
 	return {
 		repository,
@@ -313,6 +313,7 @@ export const parsePullRequestMergeInfo = (repository: string, info: RawMergeInfo
 		checkSummary: checkInfo.checkSummary,
 		autoMergeEnabled: info.autoMergeRequest !== null,
 		viewerCanMergeAsAdmin,
+		mergeQueueEnabled,
 	}
 }
 

--- a/src/services/githubSchemas.ts
+++ b/src/services/githubSchemas.ts
@@ -154,7 +154,7 @@ export const MergeInfoResponseSchema = Schema.Struct({
 export const PullRequestAdminMergeResponseSchema = Schema.Struct({
 	data: Schema.Struct({
 		repository: Schema.Struct({
-			pullRequest: Schema.NullOr(Schema.Struct({ viewerCanMergeAsAdmin: Schema.Boolean })),
+			pullRequest: Schema.NullOr(Schema.Struct({ viewerCanMergeAsAdmin: Schema.Boolean, mergeQueue: Schema.NullOr(Schema.Struct({ id: Schema.String })) })),
 		}),
 	}),
 })

--- a/src/ui/merge/useMergeFlow.ts
+++ b/src/ui/merge/useMergeFlow.ts
@@ -178,7 +178,7 @@ export const useMergeFlow = ({
 	}
 
 	const confirmMergeAction = () => {
-		if (!mergeModal.info || !mergeModal.allowedMethods || mergeModal.loading || mergeModal.running) return
+		if (!mergeModal.info || !mergeModal.allowedMethods || mergeModal.loading || mergeModal.running || mergeModal.error) return
 
 		// Second confirm: enter while pending executes the queued action with mark-ready.
 		if (mergeModal.pendingConfirm) {

--- a/src/ui/merge/useMergeFlow.ts
+++ b/src/ui/merge/useMergeFlow.ts
@@ -131,17 +131,18 @@ export const useMergeFlow = ({
 		const { repository, number } = info
 		const targetPullRequest = pullRequests.find((pullRequest) => pullRequest.repository === repository && pullRequest.number === number)
 		const previousPullRequest = targetPullRequest ?? null
+		const queueRequest = info.mergeQueueEnabled && (kindDef.kind === "now" || kindDef.kind === "auto")
 
 		if (targetPullRequest && markReady) {
 			updatePullRequest(targetPullRequest.url, (pullRequest) => (pullRequest.reviewStatus === "draft" ? { ...pullRequest, reviewStatus: "none" } : pullRequest))
 		}
-		if (targetPullRequest && kindDef.optimisticAutoMergeEnabled !== undefined) {
+		if (targetPullRequest && !queueRequest && kindDef.optimisticAutoMergeEnabled !== undefined) {
 			updatePullRequest(targetPullRequest.url, (pullRequest) => ({ ...pullRequest, autoMergeEnabled: kindDef.optimisticAutoMergeEnabled! }))
 		}
-		if (targetPullRequest && kindDef.optimisticState === "merged") markPullRequestCompleted(targetPullRequest, "merged")
+		if (targetPullRequest && !queueRequest && kindDef.optimisticState === "merged") markPullRequestCompleted(targetPullRequest, "merged")
 
 		const kind = kindDef.kind
-		const action: PullRequestMergeAction = kind === "disable-auto" ? { kind } : { kind, method }
+		const action: PullRequestMergeAction = kind === "disable-auto" ? { kind } : { kind, method, mergeQueueEnabled: info.mergeQueueEnabled }
 		const pastTense = kindDef.pastTense(method)
 
 		closeActiveModal()
@@ -169,7 +170,7 @@ export const useMergeFlow = ({
 			.catch((error) => {
 				if (markReady && markedReady) {
 					refreshPullRequests(`Merge failed for #${number}`)
-				} else if (previousPullRequest) {
+				} else if (previousPullRequest && (!queueRequest || markReady)) {
 					restoreOptimisticPullRequest(previousPullRequest)
 				}
 				flashNotice(errorMessage(error))
@@ -182,7 +183,7 @@ export const useMergeFlow = ({
 		// Second confirm: enter while pending executes the queued action with mark-ready.
 		if (mergeModal.pendingConfirm) {
 			const pending = mergeModal.pendingConfirm
-			const kindDef = getMergeKindDefinition(pending.kind)
+			const kindDef = getMergeKindDefinition(pending.kind, mergeModal.info.mergeQueueEnabled)
 			executeMergeAction(kindDef, pending.method, mergeModal.info, /* markReady = */ true)
 			return
 		}

--- a/src/ui/modals/MergeModal.tsx
+++ b/src/ui/modals/MergeModal.tsx
@@ -84,7 +84,7 @@ export const MergeModal = ({
 		if (state.error) return renderCenteredMessage(state.error, colors.error)
 		if (isLoading) return renderCenteredMessage(`${loadingIndicator} ${state.loading ? "Loading merge status" : "Loading merge methods"}`, colors.muted)
 		if (state.pendingConfirm && state.info) {
-			const kindDef = getMergeKindDefinition(state.pendingConfirm.kind)
+			const kindDef = getMergeKindDefinition(state.pendingConfirm.kind, state.info.mergeQueueEnabled)
 			const action = kindDef.title(state.pendingConfirm.method)
 			const lowered = action.charAt(0).toLowerCase() + action.slice(1)
 			return renderCenteredLines([

--- a/test/fixtures/mergeQueue.ts
+++ b/test/fixtures/mergeQueue.ts
@@ -1,0 +1,87 @@
+import { Effect, Layer, Schema } from "effect"
+import type { PullRequestItem } from "../../src/domain.ts"
+import { CommandError, CommandRunner } from "../../src/services/CommandRunner.ts"
+
+export const mergeQueuePullRequest: PullRequestItem = {
+	repository: "example/queue-demo",
+	number: 42,
+	title: "Fix release validation",
+	body: "Deterministic merge queue fixture. GitHub is simulated.",
+	author: "demo-user",
+	headRefOid: "fixture-head",
+	headRefName: "fix/release-validation",
+	baseRefName: "main",
+	defaultBranchName: "main",
+	labels: [],
+	additions: 2,
+	deletions: 1,
+	changedFiles: 1,
+	state: "open",
+	reviewStatus: "approved",
+	checkStatus: "passing",
+	checkSummary: "checks 1/1",
+	checks: [{ name: "ci", status: "completed", conclusion: "success" }],
+	autoMergeEnabled: false,
+	detailLoaded: true,
+	createdAt: new Date("2026-08-21T12:00:00Z"),
+	updatedAt: new Date("2026-08-21T12:00:00Z"),
+	closedAt: null,
+	url: "https://github.com/example/queue-demo/pull/42",
+}
+
+export interface MergeQueueFixtureOptions {
+	readonly queueEnabled: boolean
+	readonly isDraft?: boolean
+	readonly pendingChecks?: boolean
+	readonly mergeResult?: Effect.Effect<void, CommandError>
+}
+
+export const mergeQueueCommandLayer = (options: MergeQueueFixtureOptions, calls: string[][]) =>
+	Layer.succeed(
+		CommandRunner,
+		CommandRunner.of({
+			run: (command, args) => {
+				calls.push([command, ...args])
+				if (command !== "gh") return Effect.die(`Unexpected fixture command: ${command}`)
+				if (args[0] === "pr" && args[1] === "ready") return Effect.succeed({ stdout: "", stderr: "", exitCode: 0 })
+				if (args[0] !== "pr" || args[1] !== "merge") return Effect.die(`Unexpected fixture mutation: ${args.join(" ")}`)
+				if (options.queueEnabled && args.includes("--delete-branch")) {
+					return Effect.fail(
+						new CommandError({
+							command,
+							args: [...args],
+							detail: "Cannot use `-d` or `--delete-branch` when merge queue enabled",
+							cause: "gh 2.96.0 merge-queue preflight fixture",
+						}),
+					)
+				}
+				return (options.mergeResult ?? Effect.void).pipe(Effect.as({ stdout: "", stderr: "", exitCode: 0 }))
+			},
+			runSchema: (schema, command, args) => {
+				calls.push([command, ...args])
+				const response =
+					args[0] === "pr" && args[1] === "view"
+						? {
+								number: 42,
+								title: mergeQueuePullRequest.title,
+								state: "OPEN",
+								isDraft: options.isDraft ?? false,
+								mergeable: "MERGEABLE",
+								reviewDecision: "APPROVED",
+								autoMergeRequest: null,
+								statusCheckRollup: [
+									{ __typename: "CheckRun", name: "ci", status: options.pendingChecks ? "IN_PROGRESS" : "COMPLETED", conclusion: options.pendingChecks ? null : "SUCCESS" },
+								],
+							}
+						: args[0] === "repo" && args[1] === "view"
+							? { squashMergeAllowed: true, mergeCommitAllowed: true, rebaseMergeAllowed: true }
+							: args[0] === "api" && args[1] === "graphql"
+								? { data: { repository: { pullRequest: { viewerCanMergeAsAdmin: true, mergeQueue: options.queueEnabled ? { id: "fixture-queue" } : null } } } }
+								: args[0] === "api" && args[1] === "user"
+									? { login: "demo-user" }
+									: undefined
+				if (response === undefined) return Effect.die(`Unexpected fixture query: ${args.join(" ")}`)
+				return Schema.decodeUnknownEffect(schema)(response)
+			},
+		}),
+	)

--- a/test/fixtures/mergeQueue.ts
+++ b/test/fixtures/mergeQueue.ts
@@ -33,6 +33,7 @@ export interface MergeQueueFixtureOptions {
 	readonly queueEnabled: boolean
 	readonly isDraft?: boolean
 	readonly pendingChecks?: boolean
+	readonly lookupFailure?: boolean
 	readonly mergeResult?: Effect.Effect<void, CommandError>
 }
 
@@ -59,6 +60,9 @@ export const mergeQueueCommandLayer = (options: MergeQueueFixtureOptions, calls:
 			},
 			runSchema: (schema, command, args) => {
 				calls.push([command, ...args])
+				if (options.lookupFailure && args[0] === "api" && args[1] === "graphql") {
+					return Effect.fail(new CommandError({ command, args: [...args], detail: "Fixture queue lookup denied", cause: "fixture" }))
+				}
 				const response =
 					args[0] === "pr" && args[1] === "view"
 						? {

--- a/test/githubMergeQueue.test.ts
+++ b/test/githubMergeQueue.test.ts
@@ -51,6 +51,29 @@ describe("GitHubService merge queue", () => {
 })
 
 describe("production merge flow", () => {
+	for (const directConfirm of [false, true]) {
+		for (const isDraft of [false, true]) {
+			test(`failed queue lookup blocks ${directConfirm ? "direct confirmation" : "Enter"} for ${isDraft ? "draft" : "ready"} PRs`, async () => {
+				const stdout = await runIsolatedProbe(`
+					import { probeMergeFlow } from "./test/mergeQueueFlowProbe.tsx"
+					console.log(JSON.stringify(await probeMergeFlow(${JSON.stringify({ queueEnabled: true, kind: "auto", lookupFailure: true, directConfirm, isDraft })})))
+				`)
+				const result = JSON.parse(stdout)
+				expect(result.error).toBe("Fixture queue lookup denied")
+				expect(result.loading).toBe(false)
+				expect(result.errorFrame).toContain(result.error)
+				expect(result.errorFrame).not.toContain("Enable auto-merge")
+				expect(result.confirmationCalls).toEqual([])
+				expect(result.pendingConfirm).toBeNull()
+				expect(result.availableActionCount).toBe(0)
+				if (!directConfirm) expect(result.dispatch).toBe("disabled")
+				expect(result.state).toBe("open")
+				expect(result.reviewStatus).toBe(isDraft ? "draft" : "approved")
+				expect(result.autoMergeEnabled).toBe(false)
+			})
+		}
+	}
+
 	for (const queueEnabled of [false, true]) {
 		for (const kind of ["now", "auto", "admin"] as const) {
 			test(`${queueEnabled ? "queue" : "ordinary"} ${kind} keeps truthful pending and successful state`, async () => {

--- a/test/githubMergeQueue.test.ts
+++ b/test/githubMergeQueue.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test"
+import { Effect, Layer } from "effect"
+import { pullRequestMergeMethods } from "../src/domain.ts"
+import { GitHubService } from "../src/services/GitHubService.ts"
+import { mergeQueueCommandLayer } from "./fixtures/mergeQueue.ts"
+import { runIsolatedProbe } from "./isolatedProbe.ts"
+
+describe("GitHubService merge queue", () => {
+	for (const queueEnabled of [false, true]) {
+		for (const kind of ["now", "auto", "admin"] as const) {
+			for (const method of pullRequestMergeMethods) {
+				test(`${queueEnabled ? "queue" : "ordinary"} ${kind} ${method} uses safe merge flags`, async () => {
+					const calls: string[][] = []
+					const layer = GitHubService.layerNoDeps.pipe(Layer.provide(mergeQueueCommandLayer({ queueEnabled }, calls)))
+					await Effect.runPromise(
+						GitHubService.use((github) =>
+							Effect.gen(function* () {
+								const info = yield* github.getPullRequestMergeInfo("example/queue-demo", 42)
+								yield* github.mergePullRequest(info.repository, info.number, { kind, method, mergeQueueEnabled: info.mergeQueueEnabled })
+								expect(info.mergeQueueEnabled).toBe(queueEnabled)
+							}),
+						).pipe(Effect.provide(layer)),
+					)
+					const mergeCall = calls.find((call) => call[1] === "pr" && call[2] === "merge")
+					expect(mergeCall).toEqual([
+						"gh",
+						"pr",
+						"merge",
+						"42",
+						"--repo",
+						"example/queue-demo",
+						`--${method}`,
+						...(kind === "now" ? [] : [`--${kind}`]),
+						...(queueEnabled ? [] : ["--delete-branch"]),
+					])
+					expect(calls.find((call) => call[1] === "api" && call[2] === "graphql")?.find((arg) => arg.startsWith("query="))).toContain("mergeQueue { id }")
+				})
+			}
+		}
+	}
+
+	test("disabling auto-merge is unchanged", async () => {
+		const calls: string[][] = []
+		await Effect.runPromise(
+			GitHubService.use((github) => github.mergePullRequest("example/queue-demo", 42, { kind: "disable-auto" })).pipe(
+				Effect.provide(GitHubService.layerNoDeps.pipe(Layer.provide(mergeQueueCommandLayer({ queueEnabled: true }, calls)))),
+			),
+		)
+		expect(calls.filter((call) => call[1] === "pr")).toEqual([["gh", "pr", "merge", "42", "--repo", "example/queue-demo", "--disable-auto"]])
+	})
+})
+
+describe("production merge flow", () => {
+	for (const queueEnabled of [false, true]) {
+		for (const kind of ["now", "auto", "admin"] as const) {
+			test(`${queueEnabled ? "queue" : "ordinary"} ${kind} keeps truthful pending and successful state`, async () => {
+				const stdout = await runIsolatedProbe(`
+					import { probeMergeFlow } from "./test/mergeQueueFlowProbe.tsx"
+					console.log(JSON.stringify(await probeMergeFlow(${JSON.stringify({ queueEnabled, kind })})))
+				`)
+				const result = JSON.parse(stdout)
+				const queueRequest = queueEnabled && kind !== "admin"
+				expect(result.pendingState).toBe(queueRequest || kind === "auto" ? "open" : "merged")
+				expect(result.finalState).toBe(result.pendingState)
+				expect(result.autoMergeEnabled).toBe(!queueEnabled && kind === "auto")
+				expect(result.completed).toEqual(queueRequest || kind === "auto" ? [] : ["merged"])
+				expect(result.refreshes).toEqual(queueRequest ? ["Requested merge queue for #42"] : kind === "auto" ? [] : [`${kind === "admin" ? "Admin merged" : "Merged"} #42`])
+				expect(result.notices).toEqual(!queueEnabled && kind === "auto" ? ["Enabled auto-merge #42"] : [])
+				expect(result.restored).toBe(0)
+				if (queueRequest) expect(result.modalFrame).toContain("Add to merge queue")
+				if (kind === "admin") expect(result.modalFrame).toContain("(admin)")
+				if (queueEnabled && kind === "admin") expect(result.modalFrame).toContain("Bypass the merge queue")
+			})
+		}
+	}
+
+	test("queue failure leaves the PR open and reports the error", async () => {
+		const stdout = await runIsolatedProbe(`
+			import { probeMergeFlow } from "./test/mergeQueueFlowProbe.tsx"
+			console.log(JSON.stringify(await probeMergeFlow({ queueEnabled: true, kind: "now", fail: true })))
+		`)
+		const result = JSON.parse(stdout)
+		expect(result.pendingState).toBe("open")
+		expect(result.finalState).toBe("open")
+		expect(result.completed).toEqual([])
+		expect(result.refreshes).toEqual([])
+		expect(result.notices).toEqual(["Fixture merge rejected"])
+		expect(result.restored).toBe(0)
+	})
+
+	test("ordinary merge failure still rolls back optimistic completion", async () => {
+		const stdout = await runIsolatedProbe(`
+			import { probeMergeFlow } from "./test/mergeQueueFlowProbe.tsx"
+			console.log(JSON.stringify(await probeMergeFlow({ queueEnabled: false, kind: "now", fail: true })))
+		`)
+		const result = JSON.parse(stdout)
+		expect(result.pendingState).toBe("merged")
+		expect(result.finalState).toBe("open")
+		expect(result.restored).toBe(1)
+		expect(result.notices).toEqual(["Fixture merge rejected"])
+	})
+
+	test("draft queue action still confirms twice and marks ready before requesting the queue", async () => {
+		const stdout = await runIsolatedProbe(`
+			import { probeMergeFlow } from "./test/mergeQueueFlowProbe.tsx"
+			console.log(JSON.stringify(await probeMergeFlow({ queueEnabled: true, kind: "now", isDraft: true })))
+		`)
+		const result = JSON.parse(stdout)
+		expect(result.firstConfirmMutations).toEqual([])
+		expect(result.mutations.map((call: string[]) => call[2])).toEqual(["ready", "merge"])
+		expect(result.completed).toEqual([])
+		expect(result.refreshes).toEqual(["Requested merge queue for #42"])
+		expect(result.finalState).toBe("open")
+		expect(result.finalReviewStatus).toBe("none")
+	})
+
+	test("draft queue failure after marking ready refreshes rather than restoring draft state", async () => {
+		const stdout = await runIsolatedProbe(`
+			import { probeMergeFlow } from "./test/mergeQueueFlowProbe.tsx"
+			console.log(JSON.stringify(await probeMergeFlow({ queueEnabled: true, kind: "now", isDraft: true, fail: true })))
+		`)
+		const result = JSON.parse(stdout)
+		expect(result.finalState).toBe("open")
+		expect(result.finalReviewStatus).toBe("none")
+		expect(result.restored).toBe(0)
+		expect(result.refreshes).toEqual(["Merge failed for #42"])
+		expect(result.notices).toEqual(["Fixture merge rejected"])
+	})
+
+	test("pending checks request the queue without claiming auto-merge or completion", async () => {
+		const stdout = await runIsolatedProbe(`
+			import { probeMergeFlow } from "./test/mergeQueueFlowProbe.tsx"
+			console.log(JSON.stringify(await probeMergeFlow({ queueEnabled: true, kind: "auto", pendingChecks: true })))
+		`)
+		const result = JSON.parse(stdout)
+		expect(result.pendingState).toBe("open")
+		expect(result.autoMergeEnabled).toBe(false)
+		expect(result.completed).toEqual([])
+		expect(result.refreshes).toEqual(["Requested merge queue for #42"])
+		expect(result.modalFrame).toContain("Enable merge queue when ready")
+	})
+})

--- a/test/githubNormalize.test.ts
+++ b/test/githubNormalize.test.ts
@@ -397,7 +397,7 @@ describe("parsePullRequestMergeInfo", () => {
 	}
 
 	test("derives state/mergeable/reviewStatus and threads admin boolean", () => {
-		const merge = parsePullRequestMergeInfo("owner/repo", info, true)
+		const merge = parsePullRequestMergeInfo("owner/repo", info, true, false)
 		expect(merge.repository).toBe("owner/repo")
 		expect(merge.state).toBe("open")
 		expect(merge.mergeable).toBe("mergeable")
@@ -407,13 +407,13 @@ describe("parsePullRequestMergeInfo", () => {
 	})
 
 	test("auto-merge enabled when request is non-null", () => {
-		const merge = parsePullRequestMergeInfo("owner/repo", { ...info, autoMergeRequest: { something: true } }, false)
+		const merge = parsePullRequestMergeInfo("owner/repo", { ...info, autoMergeRequest: { something: true } }, false, false)
 		expect(merge.autoMergeEnabled).toBe(true)
 	})
 
 	test("closed state for anything but OPEN", () => {
-		expect(parsePullRequestMergeInfo("owner/repo", { ...info, state: "CLOSED" }, false).state).toBe("closed")
-		expect(parsePullRequestMergeInfo("owner/repo", { ...info, state: "MERGED" }, false).state).toBe("closed")
+		expect(parsePullRequestMergeInfo("owner/repo", { ...info, state: "CLOSED" }, false, false).state).toBe("closed")
+		expect(parsePullRequestMergeInfo("owner/repo", { ...info, state: "MERGED" }, false, false).state).toBe("closed")
 	})
 })
 

--- a/test/mergeActions.test.ts
+++ b/test/mergeActions.test.ts
@@ -14,6 +14,7 @@ const cleanInfo: PullRequestMergeInfo = {
 	checkSummary: "checks 5/5",
 	autoMergeEnabled: false,
 	viewerCanMergeAsAdmin: false,
+	mergeQueueEnabled: false,
 }
 
 describe("mergeKinds ordering", () => {
@@ -106,23 +107,23 @@ describe("mergeActionCliArgs", () => {
 	const action = (a: PullRequestMergeAction) => mergeActionCliArgs(a)
 
 	test("squash + now uses --squash --delete-branch", () => {
-		expect(action({ kind: "now", method: "squash" })).toEqual(["--squash", "--delete-branch"])
+		expect(action({ kind: "now", method: "squash", mergeQueueEnabled: false })).toEqual(["--squash", "--delete-branch"])
 	})
 
 	test("merge + now uses --merge --delete-branch", () => {
-		expect(action({ kind: "now", method: "merge" })).toEqual(["--merge", "--delete-branch"])
+		expect(action({ kind: "now", method: "merge", mergeQueueEnabled: false })).toEqual(["--merge", "--delete-branch"])
 	})
 
 	test("rebase + now uses --rebase --delete-branch", () => {
-		expect(action({ kind: "now", method: "rebase" })).toEqual(["--rebase", "--delete-branch"])
+		expect(action({ kind: "now", method: "rebase", mergeQueueEnabled: false })).toEqual(["--rebase", "--delete-branch"])
 	})
 
 	test("auto + rebase uses --rebase --auto --delete-branch", () => {
-		expect(action({ kind: "auto", method: "rebase" })).toEqual(["--rebase", "--auto", "--delete-branch"])
+		expect(action({ kind: "auto", method: "rebase", mergeQueueEnabled: false })).toEqual(["--rebase", "--auto", "--delete-branch"])
 	})
 
 	test("admin + merge uses --merge --admin --delete-branch", () => {
-		expect(action({ kind: "admin", method: "merge" })).toEqual(["--merge", "--admin", "--delete-branch"])
+		expect(action({ kind: "admin", method: "merge", mergeQueueEnabled: false })).toEqual(["--merge", "--admin", "--delete-branch"])
 	})
 
 	test("disable-auto ignores method and uses --disable-auto", () => {

--- a/test/mergeQueueFlowProbe.tsx
+++ b/test/mergeQueueFlowProbe.tsx
@@ -1,0 +1,147 @@
+import { RegistryContext } from "@effect/atom-react"
+import { createTestRenderer } from "@opentui/core/testing"
+import { createRoot } from "@opentui/react"
+import { Effect, Layer } from "effect"
+import * as AtomRegistry from "effect/unstable/reactivity/AtomRegistry"
+import { act, useState } from "react"
+import { visibleMergeKinds } from "../src/mergeActions.ts"
+import { CommandError } from "../src/services/CommandRunner.ts"
+import { GitHubService } from "../src/services/GitHubService.ts"
+import { githubRuntime } from "../src/services/runtime.ts"
+import { useMergeFlow, type UseMergeFlowResult } from "../src/ui/merge/useMergeFlow.ts"
+import { MergeModal } from "../src/ui/modals/MergeModal.tsx"
+import type { MergeModalState } from "../src/ui/modals/types.ts"
+import { getPullRequestMergeInfoAtom, getRepositoryMergeMethodsAtom } from "../src/ui/pullRequests/atoms.ts"
+import type { PullRequestItem } from "../src/domain.ts"
+import { mergeQueueCommandLayer, mergeQueuePullRequest } from "./fixtures/mergeQueue.ts"
+
+const deferred = () => {
+	let resolve: () => void = () => {}
+	const promise = new Promise<void>((done) => {
+		resolve = done
+	})
+	return { promise, resolve }
+}
+
+export const probeMergeFlow = async (options: { queueEnabled: boolean; kind: "now" | "auto" | "admin"; isDraft?: boolean; pendingChecks?: boolean; fail?: boolean }) => {
+	// @ts-expect-error -- React's act environment flag is intentionally global.
+	globalThis.IS_REACT_ACT_ENVIRONMENT = true
+	const started = deferred()
+	const release = deferred()
+	const finished = deferred()
+	const calls: string[][] = []
+	const mergeResult = Effect.promise(() => {
+		started.resolve()
+		return release.promise
+	}).pipe(Effect.flatMap(() => (options.fail ? Effect.fail(new CommandError({ command: "gh", args: [], detail: "Fixture merge rejected", cause: "fixture" })) : Effect.void)))
+	const layer = GitHubService.layerNoDeps.pipe(Layer.provide(mergeQueueCommandLayer({ ...options, mergeResult }, calls)))
+	const registry = AtomRegistry.make({ initialValues: [[githubRuntime.layer, layer]] })
+	const setup = await createTestRenderer({ width: 90, height: 24 })
+	const root = createRoot(setup.renderer)
+	let pr: PullRequestItem = { ...mergeQueuePullRequest, reviewStatus: options.isDraft ? "draft" : "approved" }
+	const completed: string[] = []
+	const refreshes: string[] = []
+	const notices: string[] = []
+	let restored = 0
+	let flow: UseMergeFlowResult | undefined
+	let modal: MergeModalState | undefined
+	const Harness = () => {
+		const [state, setState] = useState<MergeModalState>({
+			repository: null,
+			number: null,
+			selectedIndex: 0,
+			loading: false,
+			running: false,
+			info: null,
+			error: null,
+			selectedMethod: "squash",
+			allowedMethods: null,
+			pendingConfirm: null,
+		})
+		modal = state
+		flow = useMergeFlow({
+			mergeModal: state,
+			setMergeModal: setState,
+			selectedPullRequest: pr,
+			pullRequests: [pr],
+			closeActiveModal: () => {},
+			flashNotice: (message) => {
+				notices.push(message)
+				finished.resolve()
+			},
+			updatePullRequest: (_url, transform) => {
+				pr = transform(pr)
+			},
+			markPullRequestCompleted: (_target, state) => {
+				completed.push(state)
+				pr = { ...pr, state }
+			},
+			restoreOptimisticPullRequest: (previous) => {
+				pr = previous
+				restored += 1
+			},
+			refreshPullRequests: (message) => {
+				if (message) refreshes.push(message)
+				finished.resolve()
+			},
+		})
+		return <MergeModal state={state} modalWidth={86} modalHeight={22} offsetLeft={0} offsetTop={0} loadingIndicator="." />
+	}
+	try {
+		act(() =>
+			root.render(
+				<RegistryContext.Provider value={registry}>
+					<Harness />
+				</RegistryContext.Provider>,
+			),
+		)
+		await act(async () => {
+			flow?.openMergeModal()
+			await Effect.runPromise(
+				Effect.all([
+					AtomRegistry.getResult(registry, getPullRequestMergeInfoAtom, { suspendOnWaiting: true }),
+					AtomRegistry.getResult(registry, getRepositoryMergeMethodsAtom, { suspendOnWaiting: true }),
+				]),
+			)
+		})
+		if (!flow || !modal) throw new Error("Merge flow failed to mount")
+		const kindIndex = visibleMergeKinds(modal.info, modal.allowedMethods, modal.selectedMethod).findIndex((kind) => kind.kind === options.kind)
+		if (kindIndex < 0) throw new Error(`Missing merge action: ${options.kind}`)
+		for (let index = 0; index < kindIndex; index++) act(() => flow?.moveMergeSelection(1))
+		await setup.renderOnce()
+		const modalFrame = setup.captureCharFrame()
+		let firstConfirmMutations: string[][] = []
+		act(() => flow?.confirmMergeAction())
+		if (options.isDraft) {
+			firstConfirmMutations = calls.filter((call) => call[1] === "pr" && call[2] !== "view")
+			act(() => flow?.confirmMergeAction())
+		}
+		const pendingState = pr.state
+		const autoMergeEnabled = pr.autoMergeEnabled
+		await act(async () => {
+			await Promise.race([started.promise, finished.promise])
+		})
+		await act(async () => {
+			release.resolve()
+			await finished.promise
+		})
+		return {
+			pendingState,
+			finalState: pr.state,
+			finalReviewStatus: pr.reviewStatus,
+			autoMergeEnabled,
+			completed,
+			refreshes,
+			notices,
+			restored,
+			modalFrame,
+			firstConfirmMutations,
+			mutations: calls.filter((call) => call[1] === "pr" && call[2] !== "view"),
+		}
+	} finally {
+		release.resolve()
+		act(() => root.unmount())
+		registry.dispose()
+		setup.renderer.destroy()
+	}
+}

--- a/test/mergeQueueFlowProbe.tsx
+++ b/test/mergeQueueFlowProbe.tsx
@@ -1,10 +1,13 @@
 import { RegistryContext } from "@effect/atom-react"
+import { createDispatcher, parseKey } from "@ghui/keymap"
 import { createTestRenderer } from "@opentui/core/testing"
 import { createRoot } from "@opentui/react"
 import { Effect, Layer } from "effect"
 import * as AtomRegistry from "effect/unstable/reactivity/AtomRegistry"
 import { act, useState } from "react"
 import { visibleMergeKinds } from "../src/mergeActions.ts"
+import { buildMergeModalCtx } from "../src/keymap/contexts/mergeModalCtx.ts"
+import { mergeModalKeymap } from "../src/keymap/mergeModal.ts"
 import { CommandError } from "../src/services/CommandRunner.ts"
 import { GitHubService } from "../src/services/GitHubService.ts"
 import { githubRuntime } from "../src/services/runtime.ts"
@@ -23,7 +26,15 @@ const deferred = () => {
 	return { promise, resolve }
 }
 
-export const probeMergeFlow = async (options: { queueEnabled: boolean; kind: "now" | "auto" | "admin"; isDraft?: boolean; pendingChecks?: boolean; fail?: boolean }) => {
+export const probeMergeFlow = async (options: {
+	queueEnabled: boolean
+	kind: "now" | "auto" | "admin"
+	isDraft?: boolean
+	pendingChecks?: boolean
+	fail?: boolean
+	lookupFailure?: boolean
+	directConfirm?: boolean
+}) => {
 	// @ts-expect-error -- React's act environment flag is intentionally global.
 	globalThis.IS_REACT_ACT_ENVIRONMENT = true
 	const started = deferred()
@@ -45,6 +56,11 @@ export const probeMergeFlow = async (options: { queueEnabled: boolean; kind: "no
 	let restored = 0
 	let flow: UseMergeFlowResult | undefined
 	let modal: MergeModalState | undefined
+	const pressEnter = () => {
+		if (!flow || !modal) throw new Error("Merge flow failed to mount")
+		const context = buildMergeModalCtx({ mergeModal: modal, ...flow })
+		return createDispatcher(mergeModalKeymap, () => context).dispatch(parseKey("return")).kind
+	}
 	const Harness = () => {
 		const [state, setState] = useState<MergeModalState>({
 			repository: null,
@@ -99,22 +115,50 @@ export const probeMergeFlow = async (options: { queueEnabled: boolean; kind: "no
 			flow?.openMergeModal()
 			await Effect.runPromise(
 				Effect.all([
-					AtomRegistry.getResult(registry, getPullRequestMergeInfoAtom, { suspendOnWaiting: true }),
+					AtomRegistry.getResult(registry, getPullRequestMergeInfoAtom, { suspendOnWaiting: true }).pipe(Effect.result),
 					AtomRegistry.getResult(registry, getRepositoryMergeMethodsAtom, { suspendOnWaiting: true }),
 				]),
 			)
 		})
 		if (!flow || !modal) throw new Error("Merge flow failed to mount")
+		if (options.lookupFailure) {
+			await setup.renderOnce()
+			const errorFrame = setup.captureCharFrame()
+			const context = buildMergeModalCtx({ mergeModal: modal, ...flow })
+			const callsBeforeConfirm = calls.length
+			let dispatch = "direct"
+			await act(async () => {
+				if (options.directConfirm) flow?.confirmMergeAction()
+				else dispatch = pressEnter()
+			})
+			return {
+				error: modal.error,
+				loading: modal.loading,
+				availableActionCount: context.availableActionCount,
+				dispatch,
+				confirmationCalls: calls.slice(callsBeforeConfirm),
+				state: pr.state,
+				reviewStatus: pr.reviewStatus,
+				autoMergeEnabled: pr.autoMergeEnabled,
+				pendingConfirm: modal.pendingConfirm,
+				errorFrame,
+			}
+		}
+		if (modal.error) throw new Error(modal.error)
 		const kindIndex = visibleMergeKinds(modal.info, modal.allowedMethods, modal.selectedMethod).findIndex((kind) => kind.kind === options.kind)
 		if (kindIndex < 0) throw new Error(`Missing merge action: ${options.kind}`)
 		for (let index = 0; index < kindIndex; index++) act(() => flow?.moveMergeSelection(1))
 		await setup.renderOnce()
 		const modalFrame = setup.captureCharFrame()
 		let firstConfirmMutations: string[][] = []
-		act(() => flow?.confirmMergeAction())
+		act(() => {
+			pressEnter()
+		})
 		if (options.isDraft) {
 			firstConfirmMutations = calls.filter((call) => call[1] === "pr" && call[2] !== "view")
-			act(() => flow?.confirmMergeAction())
+			act(() => {
+				pressEnter()
+			})
 		}
 		const pendingState = pr.state
 		const autoMergeEnabled = pr.autoMergeEnabled


### PR DESCRIPTION
## Why

Merging a pull request into a branch with a merge queue fails because ghui always passes `--delete-branch`. GitHub CLI rejects that flag for queue targets, including explicit admin merges.

Closes #57.

## What Changes

| Target and action | New behavior |
| --- | --- |
| Ordinary branch, successful action | Existing merge flags, branch deletion, and optimistic state remain unchanged. |
| Queue branch, normal or auto | Omit branch deletion, keep the PR open without inventing an auto-merge state, refresh after success, and report `Requested merge queue for #42`. |
| Queue branch, admin | Omit branch deletion while retaining explicit `--admin`, optimistic completion, and the `Admin merged` notice. The modal explains the queue bypass. |
| Any target, lookup failure | Block Enter and direct confirmation rather than execute a hidden action using seeded merge information. Preserve ready/draft and open state. |

Queue detection reads `PullRequest.mergeQueue` alongside the existing admin-permission query. This is the queue for the PR's base branch, not whether the PR already has a queue entry. Draft PRs retain the two-stage confirmation and mark-ready flow.

## Demo

https://github.com/user-attachments/assets/a17de577-bcf4-4350-9666-621236fdeb9f

Matched production GHUI TUI runs: base `090a4d5` and final fix `57d6d1e`, refreshed after the error-gate follow-up, using the same `m`, then Enter interaction at 120x26. The GitHub backend is simulated; merge-info decoding, CLI argument construction, merge flow, rendering, and key handling are production code from each revision. Both recordings use the same fixture from `57d6d1e`. Startup is trimmed; playback is 1x with 1.5-second modal and 3.5-second result-frame holds. Exported at 60fps. Also verified both revisions at 84x26.

## Scope

This fixes merge-queue targets and blocks confirmation after lookup errors within the existing merge workflow. It does not add queue management or change successful ordinary merge behavior. A patch changeset is included.

## Verification

```sh
bun run test --test-name-pattern 'production merge flow|GitHubService merge queue'
bun run format:check
bun run typecheck
bun run lint
bun run test
bun run test:keymap
bun run package:smoke
bun run changeset:status
git diff --check
```

All passed at final head `57d6d1e`: 34 focused regressions, 578 tests in the full command, and 131 keymap tests. The full suite emitted nonfatal TreeSitter teardown warnings. Verified with Bun 1.4.0 and the repository-pinned Effect/Atom beta.90 dependencies. Supplemental typechecking of the new tests also passed.

Read-only GitHub GraphQL introspection confirmed the queue field and its meaning; the query validated against GitHub. GitHub CLI 2.96.0 source confirms the deletion rejection, automatic queue request, and explicit admin bypass. No live GitHub merge was performed; mutation verification uses a fake command runner and real merge-flow hook tests.

Four production regressions verify that lookup errors block Enter/direct confirmation for ready/draft PRs without command calls or state changes. An independent production hook/keymap probe still reproduces the hidden request on base `090a4d5` and confirms disabled dispatch with no mutations on final head `57d6d1e`.
