### PR TITLE
chore(release): prepare 0.9.1

### DIFF
--- a/.changeset/merge-queue-targets.md
+++ b/.changeset/merge-queue-targets.md
@@ -1,5 +1,0 @@
----
-"@kitlangton/ghui": patch
----
-
-Fix merging pull requests into branches with a merge queue: avoid requesting branch deletion, keep queued pull requests open while refreshing, and report queue requests separately from completed merges. Admin merges still explicitly bypass the queue. Block merge confirmation after lookup failures.

--- a/.changeset/restore-copied-metadata.md
+++ b/.changeset/restore-copied-metadata.md
@@ -1,5 +1,0 @@
----
-"@kitlangton/ghui": patch
----
-
-Restore branch, review, and check details when copying pull request metadata, and comment counts and labels when copying issue metadata.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @kitlangton/ghui
 
+## 0.9.1
+
+### Patch Changes
+
+- 45e2279: Fix merging pull requests into branches with a merge queue: avoid requesting branch deletion, keep queued pull requests open while refreshing, and report queue requests separately from completed merges. Admin merges still explicitly bypass the queue. Block merge confirmation after lookup failures.
+- 090a4d5: Restore branch, review, and check details when copying pull request metadata, and comment counts and labels when copying issue metadata.
+
 ## 0.9.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@kitlangton/ghui",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"description": "Terminal UI for GitHub pull requests",
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
## Why

The published 0.9.0 CLI rejects merges into branches with a merge queue and omits previously available fields from copied item metadata. The fixes are already merged in [#58](https://github.com/kitlangton/ghui/pull/58) and [#59](https://github.com/kitlangton/ghui/pull/59); this prepares their patch release.

## What Changes

Apply the two existing patch changesets together as 0.9.1, update the changelog, and remove the consumed changesets.

| Maintenance Fix | Behavior Included in 0.9.1 |
| --- | --- |
| Copied metadata, #58 | PR copies include branch, review, check summary, and failing checks; issue copies include comment count and labels. |
| Merge queues, #59 | Queue targets omit branch deletion. Queue requests keep the PR open and refresh its status; explicit admin merges still bypass the queue. Lookup failures block confirmation. |

## Scope

Release metadata only. These two maintenance PRs are the entire delta since v0.9.0; no pending feature PRs, dependency updates, or publishing-workflow changes are included. npm publication and Homebrew automation start separately when the GitHub release is published.

## Verification

```bash
bun install --frozen-lockfile
bun run changeset:status
bun run changeset:version
bun run format:check
bun run typecheck
bun run lint
bun run test
bun run test:keymap
bun run package:smoke
bun install --frozen-lockfile --os '*' --cpu '*'
bun run build:standalone -- all
GHUI_REUSE_RELEASE_BINARY=1 bun run build:npm-packages -- all
bun run build:npm-packages -- main
bun run build:cli
git diff --check
bun run changeset:status -- --since HEAD
```

All checks pass: 578 tests in the full command and 131 in the dedicated keymap command, with nonfatal TreeSitter teardown warnings in the full suite. Verified using Bun 1.4.0, Node 26.5.0, npm 11.17.0, and the repository-pinned Effect/Atom beta.90 dependencies. The publisher uses Node 24 and native platform runners.

Ran `npm pack --dry-run --json` and actual `npm pack` on all five generated packages. Inspected exact file allowlists, 0.9.1 metadata, all four optional dependencies, executable modes, matching binary hashes, and all four standalone archive checksums. macOS arm64 and x64 binaries report 0.9.1 and help text; x64 was executed through Rosetta. Linux binaries were cross-built and inspected, not executed locally.

Installed the packed main and macOS arm64 packages into a clean npm consumer with an isolated home. The consumer contains only the shim and platform binary package, with no source checkout or workspace dependency; version/help and real TUI startup pass without Bun on PATH. Using termctrl 0.5.0 and GHUI's built-in mock GitHub backend, verified repository navigation, command-palette interaction, and layouts at 120x36 and 84x26. No live GitHub mutation was performed.

All-target preflight required installing foreign optional dependencies with the frozen lockfile; the publisher builds each target on its native runner. No dependencies or lockfile changed. Pending changesets are empty against the prepared release HEAD; no artificial changeset was added for release metadata.
